### PR TITLE
Use Circle 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2.0
 
 jobs:
   test:


### PR DESCRIPTION
We want to trigger this acceptance test remotely.
This is only supported by Circle API 2.0 not 2.1

Downgrade so we can envoke this job via another Circle job.

https://circleci.com/docs/2.0/api-job-trigger/#section=jobs