### PR TITLE
integrate filestore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 .datastore
 .runner
 .pdf-generator
+.service-token-cache
 .DS_Store

--- a/acceptance-tests/output-recorder/app.rb
+++ b/acceptance-tests/output-recorder/app.rb
@@ -4,6 +4,13 @@ class App < Sinatra::Base
   EMAIL_RESULT_FILE = '/tmp/email.json'
   JSON_RESULT_FILE = '/tmp/json'
 
+  delete '/teardown' do
+    File.delete(EMAIL_RESULT_FILE)
+    File.delete(JSON_RESULT_FILE)
+
+    status 200
+  end
+
   post '/email' do
     File.open(EMAIL_RESULT_FILE, 'w') { |file| file.write(params.to_json) }
 

--- a/acceptance-tests/spec/email_with_pdf_spec.rb
+++ b/acceptance-tests/spec/email_with_pdf_spec.rb
@@ -5,6 +5,10 @@ require 'mail'
 require 'pdf-reader'
 
 describe 'Filling out an Email output form' do
+  before :each do
+    HTTParty.delete(ENV.fetch('RECORDER_TEARDOWN_ENDPOINT'))
+  end
+
   it 'sends an email with the submission in a PDF' do
     visit 'http://runner-app:3000'
     click_on 'Start'
@@ -46,6 +50,10 @@ describe 'Filling out an Email output form' do
 
     # autocomplete
     fill_in 'page_autocomplete--autocomplete_autocomplete', with: "California Spangled\n" # the new line "presses enter" on the selected option
+    continue
+
+    # upload
+    # attach_file("upload[1]", 'spec/fixtures/files/hello_world.txt')
     continue
 
     click_on 'Send complaint'

--- a/acceptance-tests/spec/fixtures/files/hello_world.txt
+++ b/acceptance-tests/spec/fixtures/files/hello_world.txt
@@ -1,0 +1,1 @@
+hello world

--- a/acceptance-tests/spec/json_output_spec.rb
+++ b/acceptance-tests/spec/json_output_spec.rb
@@ -2,8 +2,13 @@ require 'capybara/rspec'
 require 'spec_helper'
 require 'httparty'
 require 'jwe'
+require 'open-uri'
 
 describe 'JSON Output' do
+  before :each do
+    HTTParty.delete(ENV.fetch('RECORDER_TEARDOWN_ENDPOINT'))
+  end
+
   it 'sends the JSON payload to the specified endpoint' do
     visit 'http://runner-app:3000'
     click_on 'Start'
@@ -47,14 +52,21 @@ describe 'JSON Output' do
     fill_in 'page_autocomplete--autocomplete_autocomplete', with: "California Spangled\n" # the new line "presses enter" on the selected option
     continue
 
+    # upload
+    attach_file("upload[1]", 'spec/fixtures/files/hello_world.txt')
+    continue
+
     click_on 'Send complaint'
 
     encrypted_result = wait_for_json_submission
 
     result = JSON.parse(JWE.decrypt(encrypted_result, ENV.fetch('SERVICE_OUTPUT_JSON_KEY')), symbolize_names: true)
+    submission_answers_without_upload = result[:submissionAnswers].reject{|k,_| k == :upload}
+    uploads = result[:submissionAnswers][:upload]
+    upload = result[:submissionAnswers][:upload][0]
 
     expect(result).to include(serviceSlug: 'slug')
-    expect(result).to include(submissionAnswers: {
+    expect(submission_answers_without_upload).to eql({
       first_name: 'Bob',
       last_name: 'Smith',
       'has-email': 'yes',
@@ -67,7 +79,50 @@ describe 'JSON Output' do
       'checkbox-apples': 'yes'
     })
 
-    expect(result).to include(attachments: [])
+    expect(uploads.size).to eql(1)
+    expect(upload[:allowed_types]).to eql(
+      ["text/plain",
+       "image/jpeg",
+       "image/bmp",
+       "image/x-ms-bmp",
+       "image/png",
+       "image/tiff",
+       "application/pdf",
+       "application/msword",
+       "application/vnd.openxmlformats-officedocument.wordprocessingml.document"])
+
+    four_weeks = 28 * 24 * 60 * 60
+    expect(Time.at(upload[:date])).to be_within(300).of(Time.at(Time.now.to_i + four_weeks))
+    expect(upload[:destination]).to eql('/tmp/uploads')
+    expect(upload[:encoding]).to eql('7bit')
+    expect(upload[:fieldname]).to eql('upload[1]')
+    expect(upload[:filename].size).to be > 0
+    expect(upload[:fingerprint]).to eql("28d-a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447")
+    expect(upload[:maxSize]).to eql(5242880)
+    expect(upload[:mimetype]).to eql('text/plain')
+    expect(upload[:originalname]).to eql('hello_world.txt')
+    expect(upload[:path]).to match(/\/tmp\/uploads\/\S{32}/)
+    expect(upload[:size]).to eql(12)
+    expect(upload[:type]).to eql('text/plain')
+    expect(upload[:url]).to match(/http:\/\/filestore-app:3000\/service\/slug\/user\/\S{36}\/28d-\S{64}/)
+    expect(upload[:uuid]).to match(/\S{36}/)
+
+    expect(result[:attachments].size).to eql(1)
+    expect(result[:attachments][0][:encryption_iv].size).to eql(24)
+    expect(result[:attachments][0][:encryption_key].size).to eql(44)
+    expect(result[:attachments][0][:filename]).to eql('hello_world.txt')
+    expect(result[:attachments][0][:mimetype]).to eql('text/plain')
+    expect(result[:attachments][0][:url].size).to eql(337)
+
+    file_contents = open(result[:attachments][0][:url], 'rb').read
+
+    crypto = Cryptography.new(encryption_key: Base64.strict_decode64(result[:attachments][0][:encryption_key]),
+                              encryption_iv: Base64.strict_decode64(result[:attachments][0][:encryption_iv]))
+
+    decrypted_file_contents = crypto.decrypt(file: file_contents)
+
+    expect(decrypted_file_contents).to eql("hello world\n")
+
     expect(result).to have_key(:submissionId)
   end
 
@@ -75,13 +130,13 @@ describe 'JSON Output' do
     click_on 'Continue'
   end
 
-  def wait_for_json_submission(tries = 0, max_tries = 10)
+  def wait_for_json_submission(tries = 0, max_tries = 15)
     until HTTParty.get(ENV.fetch('JSON_ENDPOINT')).success?
       p 'waiting for JSON result'
       fail 'JSON assertion timeout' if tries >= max_tries
 
       tries += 1
-      sleep 2
+      sleep 1
     end
 
     HTTParty.get(ENV.fetch('JSON_ENDPOINT')).body

--- a/acceptance-tests/spec/spec_helper.rb
+++ b/acceptance-tests/spec/spec_helper.rb
@@ -13,4 +13,6 @@ RSpec.configure do |c|
 
   Capybara.app_host = 'http://localhost:3003'
   c.include Capybara::DSL
+
+  Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].each {|f| require f}
 end

--- a/acceptance-tests/spec/support/cryptography.rb
+++ b/acceptance-tests/spec/support/cryptography.rb
@@ -1,0 +1,30 @@
+class Cryptography
+  def initialize(encryption_key:, encryption_iv:)
+    @encryption_key = encryption_key
+    @encryption_iv = encryption_iv
+  end
+
+  def encrypt(file:)
+    cipher.encrypt
+    cipher.iv = encryption_iv
+    cipher.key = encryption_key
+    encrypted_data = cipher.update(file) + cipher.final
+    encrypted_data.unpack1('H*')
+  end
+
+  def decrypt(file:)
+    cipher.decrypt
+    cipher.iv = encryption_iv
+    cipher.key = encryption_key
+    data = [file].pack('H*').unpack('C*').pack('c*')
+    cipher.update(data) + cipher.final
+  end
+
+  def cipher
+    @cipher ||= OpenSSL::Cipher.new 'AES-256-CBC'
+  end
+
+  private
+
+  attr_accessor :encryption_key, :encryption_iv
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,13 +35,37 @@ services:
       SERVICE_PATH: ./forms/email-output
       SUBMITTER_URL: http://submitter-app:3000
       USER_DATASTORE_URL: http://datastore-app:3000
-      USER_FILESTORE_URL: http://filestore:3000
+      USER_FILESTORE_URL: http://filestore-app:3000
       SERVICE_SECRET: "xyz"
       SERVICE_TOKEN: "xyz"
       SERVICE_SLUG: slug
       SERVICE_OUTPUT_EMAIL: "bob.admin@digital.justice.gov.uk"
       SERVICE_OUTPUT_JSON_ENDPOINT: 'http://output-recorder:3000/json'
       SERVICE_OUTPUT_JSON_KEY: '19a56ee0e50dd83g'
+
+  filestore-app:
+    container_name: filestore-app
+    build:
+      context: .filestore
+      dockerfile: ./Dockerfile
+    ports:
+      - 10001:3000
+    environment:
+      RAILS_ENV: development
+      AWS_ACCESS_KEY_ID: 'qwerty'
+      AWS_SECRET_ACCESS_KEY: 'qwerty'
+      AWS_S3_EXTERNAL_BUCKET_ACCESS_KEY_ID: 'qwerty'
+      AWS_S3_EXTERNAL_BUCKET_SECRET_ACCESS_KEY: 'qwerty'
+      AWS_S3_EXTERNAL_BUCKET_NAME: 'external-filestore-bucket'
+      SENTRY_DSN: ''
+      KEY_ENCRYPTION_IV: '1234567890123456'
+      AWS_S3_BUCKET_NAME: 'filestore-bucket'
+      ENCRYPTION_KEY: '12345678901234561234567890123456'
+      ENCRYPTION_IV: '1234567890123456'
+      # SERVICE_TOKEN: "xyz"
+      # SECRET_KEY_BASE: "xxxyyy"
+      # MAX_IAT_SKEW_SECONDS: "60"
+      SERVICE_TOKEN_CACHE_ROOT_URL: "http://service-token-cache-app:3000"
 
   submitter-db:
     image: postgres:10.9-alpine
@@ -119,10 +143,41 @@ services:
       - 3002:3000
 
   output-recorder:
+    container_name: output-recorder
     build:
       context: ./acceptance-tests/output-recorder
     ports:
       - 3003:3000
+
+  service-token-cache-app:
+    container_name: service-token-cache-app
+    build:
+      context: .service-token-cache
+      dockerfile: ./Dockerfile
+    environment:
+      SENTRY_DSN: "whatever"
+      RAILS_ENV: development
+      RAILS_LOG_TO_STDOUT: "true"
+      REDIS_URL: service-token-cache-redis
+      SERVICE_TOKEN_CACHE_TTL: "300"
+    depends_on:
+      - service-token-cache-redis
+    ports:
+      - 3004:3000
+
+  service-token-cache-redis:
+    container_name: service-token-cache-redis
+    image: redis:5.0.6-alpine
+
+  localstack:
+    container_name: localstack
+    image: localstack/localstack:latest
+    ports:
+      - '4563-4599:4563-4599'
+      - '8055:8080'
+    environment:
+      - SERVICES=s3
+      - DEBUG=1
 
   acceptance-tests:
     build:
@@ -130,13 +185,17 @@ services:
     environment:
       EMAIL_ENDPOINT: 'http://output-recorder:3000/email'
       JSON_ENDPOINT: 'http://output-recorder:3000/json'
+      RECORDER_TEARDOWN_ENDPOINT: 'http://output-recorder:3000/teardown'
       SERVICE_OUTPUT_JSON_KEY: '19a56ee0e50dd83g'
     depends_on:
       - runner-app
+      - localstack
+      - service-token-cache-app
       - submitter-db
       - datastore-db
       - pdf-generator
       - datastore-app
+      - filestore-app
       - submitter-app
       - submitter-worker
       - output-recorder

--- a/forms/email-output/metadata/page/page.start.json
+++ b/forms/email-output/metadata/page/page.start.json
@@ -17,6 +17,7 @@
     "page.number",
     "page.select",
     "page.autocomplete",
+    "page.upload",
     "page.check-answers",
     "page.complaint-sent"
   ],

--- a/forms/email-output/metadata/page/page.upload.json
+++ b/forms/email-output/metadata/page/page.upload.json
@@ -1,0 +1,41 @@
+{
+  "_id": "page.upload",
+  "_type": "page.singlequestion",
+  "components": [
+    {
+      "_id": "page.document-upload--fileupload.auto_name__1",
+      "_type": "fileupload",
+      "errors": {
+        "accept": {
+          "any": "The selected file must be a JPG, BMP, PNG, TIF, PDF, DOC or DOCX",
+          "any:cy": "Rhaid i'r ffeil fod yn JPG, BMP, PNG, TIF, PDF, DOC neu DOCX"
+        },
+        "maxSize": {
+          "any": "too huge",
+          "any:cy": "Rhaid i'r ffeil fod yn llai na 5MB"
+        }
+      },
+      "hint": "You can upload your documents as scanned copies or photos of the originals",
+      "hint:cy": "Gallwch lwytho eich dogfennau fel copïau wedi eu sganio neu luniau o'r gwreiddiol",
+      "label": "Upload documents",
+      "label:cy": "Llwytho dogfennau",
+      "name": "upload",
+      "validation": {
+        "required": false,
+        "accept": [
+          "text/plain",
+          "image/jpeg",
+          "image/bmp",
+          "image/x-ms-bmp",
+          "image/png",
+          "image/tiff",
+          "application/pdf",
+          "application/msword",
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        ],
+        "maxSize": "5242880"
+      }
+    }
+  ],
+  "url": "/upload"
+}

--- a/scripts/wait_for_apps
+++ b/scripts/wait_for_apps
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-for app in datastore-app submitter-app pdf-generator; do
+for app in output-recorder datastore-app filestore-app submitter-app pdf-generator service-token-cache-app; do
     until docker exec $app wget http://localhost:3000/health -O - | grep healthy; do
         echo "Waiting for ${app} to start accepting traffic...";
         sleep 1


### PR DESCRIPTION
- add filestore component
- add service token cache - only used for file upload name
- add redis - needed by service token cache
- add localstack for s3 mocking
- output recorder now has teardown endpoint
- wait script now also waits for output recorder
- add upload page to form - upload is optional
- test file upload via json - decrypts file to verfify
- limitation: file upload for email not tested as output recorder
  limited to one email