### PR TITLE
remove volume from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,5 +213,3 @@ services:
       - submitter-app
       - submitter-worker
       - output-recorder
-    volumes:
-      - ./acceptance-tests:/usr/src/app


### PR DESCRIPTION
- this causes the tests fail as they should be due to an incorrect volume mount which was causing no tests to run therefore returning correct exit code therefore always passing
- it will be fixed in subsequent PR