### PR TITLE
Make sure save and return mock apps simulates submitter

### DIFF
--- a/mock-apps/save-and-return-simulator/app.rb
+++ b/mock-apps/save-and-return-simulator/app.rb
@@ -9,11 +9,11 @@ post '/email' do
   data = request.body.read
   parsed_data = JSON.generate(JSON.parse(data))
   if File.write(EMAIL_CONTENT_FILE, parsed_data)
-    status :ok
-    body "Ok"
+    status :created
+    json({})
   else
     status :bad_request
-    body "Unable to generate params"
+    json(name: 'bad-request.invalid-parameters')
   end
 end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/2Qgzviz6/300-fix-save-and-return-in-runner-part-2)

## Context

When starting the runner pointing to this mocked app, the runner was returning 500 errors because the mocked app was returning 200 and not 201.

So this PR addresses by making sure the mocked app:

Returns created (201) and an empty JSON response.
Bad request and returns a specific error message.

So this commit mimics the same behavior to save and return works on the runner as expected.