### PR TITLE
Change order of setup localstack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ serve: build
 	./scripts/wait_for_services_apps.sh
 	./scripts/wait_for_features_apps.sh
 	./scripts/wait_for_components_apps.sh
+	./scripts/setup_localstack.sh
 
 spec: serve
 	docker-compose run tests bundle exec rspec

--- a/scripts/setup_localstack.sh
+++ b/scripts/setup_localstack.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -ex
+
+until docker exec localstack wget http://localhost:8080/health -O - | grep '{"status":"OK"}'; do
+  echo "Waiting for localstack to start accepting traffic...";
+  sleep 1
+done
+
+docker-compose exec localstack sh -c "AWS_ACCESS_KEY_ID=qwerty AWS_SECRET_KEY=qwerty AWS_SECRET_ACCESS_KEY=qwerty aws --endpoint-url=http://localhost:4572 s3 mb s3://filestore-bucket"
+docker-compose exec localstack sh -c "AWS_ACCESS_KEY_ID=qwerty AWS_SECRET_KEY=qwerty AWS_SECRET_ACCESS_KEY=qwerty aws --endpoint-url=http://localhost:4572 s3api put-bucket-acl --bucket filestore-bucket --acl public-read"
+docker-compose exec localstack sh -c "AWS_ACCESS_KEY_ID=qwerty AWS_SECRET_KEY=qwerty AWS_SECRET_ACCESS_KEY=qwerty aws --endpoint-url=http://localhost:4572 s3 mb s3://external-filestore-bucket"
+docker-compose exec localstack sh -c "AWS_ACCESS_KEY_ID=qwerty AWS_SECRET_KEY=qwerty AWS_SECRET_ACCESS_KEY=qwerty aws --endpoint-url=http://localhost:4572 s3api put-bucket-acl --bucket external-filestore-bucket --acl public-read"

--- a/scripts/setup_test_env.sh
+++ b/scripts/setup_test_env.sh
@@ -4,8 +4,3 @@ set -ex
 
 # adds a test token to use in end to end test
 docker-compose exec service-token-cache-app sh -c "bundle exec rails runner \"Adapters::RedisCacheAdapter.put('encoded-public-key-slug', 'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUEzU1RCMkxnaDAyWWt0K0xxejluNgo5MlNwV0xFdXNUR1hEMGlmWTBuRHpmbXF4MWVlbHoxeHhwSk9MZXRyTGdxbjM3aE1qTlkwL25BQ2NNZHVFSDlLClhycmFieFhYVGwxeVkyMStnbVd4NDlOZVlESW5iZG0rNnM1S3ZMZ1VOTjdYVmNlUDlQdXFaeXN4Q1ZBNFRubUwKRURLZ2xTV2JVeWZ0QmVhVENKVkk2NFoxMmRNdFBiQWd4V0FmZVNMbGI3QlBsc0htL0gwQUFMK25iYU9Da3d2cgpQSkRMVFZPek9XSE1vR2dzMnJ4akJIRC9OV05ac1RWUWFvNFh3aGVidWRobHZNaWtFVzMyV0tnS3VISFc4emR2ClU4TWozM1RYK1picVhPaWtkRE54dHd2a1hGN0xBM1loOExJNUd5ZDlwNmYyN01mbGRnVUlIU3hjSnB5MUo4QVAKcXdJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg==')\""
-
-docker-compose exec localstack sh -c "AWS_ACCESS_KEY_ID=qwerty AWS_SECRET_KEY=qwerty AWS_SECRET_ACCESS_KEY=qwerty aws --endpoint-url=http://localhost:4572 s3 mb s3://filestore-bucket"
-docker-compose exec localstack sh -c "AWS_ACCESS_KEY_ID=qwerty AWS_SECRET_KEY=qwerty AWS_SECRET_ACCESS_KEY=qwerty aws --endpoint-url=http://localhost:4572 s3api put-bucket-acl --bucket filestore-bucket --acl public-read"
-docker-compose exec localstack sh -c "AWS_ACCESS_KEY_ID=qwerty AWS_SECRET_KEY=qwerty AWS_SECRET_ACCESS_KEY=qwerty aws --endpoint-url=http://localhost:4572 s3 mb s3://external-filestore-bucket"
-docker-compose exec localstack sh -c "AWS_ACCESS_KEY_ID=qwerty AWS_SECRET_KEY=qwerty AWS_SECRET_ACCESS_KEY=qwerty aws --endpoint-url=http://localhost:4572 s3api put-bucket-acl --bucket external-filestore-bucket --acl public-read"


### PR DESCRIPTION
## Context

The current acceptance pipeline it is too unstable.

Sometimes the test passes and sometimes it fails.

## Why the tests are failing?

In the setup_test_env.sh we try to create the buckets for the filestore to use.

The problem is that sometimes the localstack didn't start the whole stack (s3, Dynamo, etc):

```
requests.exceptions.ConnectionError: 
HTTPConnectionPool(host='127.0.0.1', port=4563):
 Max retries exceeded with URL: 
/filestore-bucket (Caused by NewConnectionError
('<urllib3.connection.HTTPConnection 
object at 0x7f9064847550>: Failed to establish a new connection: 
[Errno 111] Connection refused'))
```

## Solution

Move the localstack setup (bucket creation) to the last thing in the build.

**But this is not enough because we need to wait for localstack to be accepting requests**. That's the reason that sometimes my machine fails on the localstack (this is happening for a while here).

I added a small loop that waits for localstack to be running in order to the bucket creation to be done, which it solves the pipeline and makes the pipeline *stable and strong*.