### PR TITLE
Fix when you run runner locally and setup multiple times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ services-post-install:
 	cp Procfil* .runner
 	cp Dockerfile.forms .runner
 	cp Gemfile .runner/Gemfile
-	cp -R ./integration .runner/integration
-	cp -R forms .runner/forms
+	cp -R ./integration/ .runner/integration/
+	cp -R forms/ .runner/forms/
 	echo HEAD > .runner/APP_SHA
 
 services-build:


### PR DESCRIPTION
When you run multiple times the command make services-local
the folders are been duplicated like .runner/integration/integration
I forgot to add a '/' to the cp command. Adding this makes the
services container to link to local machine and start container
multiple times