### PR TITLE
Run Features and Components separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,18 @@ restart:
 spec:
 	docker-compose run integration bundle exec rspec spec
 
+feature:
+ifndef FEATURE
+	$(error FEATURE is required)
+endif
+	docker-compose run integration bundle exec rspec spec/features/$(FEATURE)_spec.rb
+
+component:
+ifndef COMPONENT
+	$(error COMPONENT is required)
+endif
+	docker-compose run integration bundle exec rspec spec/components/$(COMPONENT)_spec.rb
+
 ## Experimental ##
 spec-ci:
 	docker-compose -f docker-compose.ci.yml run integration bundle exec rspec spec/components/text_spec.rb

--- a/README.md
+++ b/README.md
@@ -37,6 +37,39 @@ Commands to start, stop or restart the containers:
     $ make stop
     $ make restart
 
+### Features and Components
+
+It is possible to fun a set of feature or component specs instead of the whole suite:
+
+    $ make feature FEATURE=save_and_return_module
+
+or
+
+    $ make component COMPONENT=autocomplete
+
+Available features:
+
+- conditional_steps
+- email_output
+- json_output
+- maintenance_mode
+- save_and_return_module
+
+Available components:
+
+- autocomplete
+- checkboxes
+- conditionals_and_upload
+- date
+- email
+- fieldset
+- number
+- radios
+- select
+- text
+- textarea
+- upload
+
 ## Glossary
 
 The acceptance tests uses a glossary of terms:


### PR DESCRIPTION
A little bit of convenience to save time running the tests if we are making changes to individual components or features.