### PR TITLE
Remove emails older than a day

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,26 @@ jobs:
       - run:
           name: Run acceptance tests
           command: make spec-ci
+  clear_old_emails:
+    docker:
+      - image: circleci/ruby:latest
+    steps:
+      - run:
+          name: Clear old emails
+          command: make clear-emails
 
 workflows:
   version: 2
   commit-workflow:
     jobs:
       - test
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 6 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - clear_old_emails

--- a/Makefile
+++ b/Makefile
@@ -135,3 +135,7 @@ endif
 ## Experimental ##
 spec-ci:
 	docker-compose -f docker-compose.ci.yml run integration_ci bundle exec parallel_rspec spec --exclude-pattern 'spec/features/save_and_return_module_spec.rb' -n 4
+
+## Clears out emails older than 24 hours from the gmail inbox that receives test submissions
+clear-emails:
+	ruby ./scripts/clear_emails.rb

--- a/scripts/clear_emails.rb
+++ b/scripts/clear_emails.rb
@@ -1,0 +1,28 @@
+require './integration/spec/support/email_output_service/google_service'
+
+USER_ID = 'me'.freeze
+
+service = GoogleService.new.authenticated_service
+emails = service.list_user_messages(USER_ID).messages
+twenty_four_hours_ago = Time.now - (3600 * 24)
+
+Array(emails).each do |email|
+  message = service.get_user_message(USER_ID, email.id)
+
+  begin
+    subject = message.payload.headers.find { |h| h.name == 'Subject' }&.value
+    received = message.payload.headers.find { |h| h.name == 'Received' }&.value
+    time_received = Time.parse(/[^;]*$/.match(received)[0].strip)
+
+    puts "Checking receipt time for #{subject}"
+    if time_received <= twenty_four_hours_ago
+      puts "Trashing email older than 24 hours => #{subject}"
+      service.trash_user_message(USER_ID, email.id)
+    end
+  rescue TypeError
+    puts "********************************************\n"
+    puts "Unable to parse date for email => #{subject}\n"
+    puts "********************************************\n"
+    next
+  end
+end


### PR DESCRIPTION
Sometimes the acceptance tests will fail during a run, but after the submission email has been sent. In those instances the email is not cleared.

This script will clear any that are older than a day.

The job will run every morning on CircleCI

https://trello.com/c/VoAJ6iqt/932-clear-email-older-than-24-hours