### PR TITLE
Set Gemfile path for bundle install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - checkout
       - run:
           name: Prepare the repository
-          command: bundle install
+          command: BUNDLE_GEMFILE=./integration/Gemfile bundle install
       - run:
           name: Clear old emails
           command: make clear-emails


### PR DESCRIPTION
The clear-emails script doesn't run in a docker container so we need to provide the path to the correct Gemfile.