### PR TITLE
Test pdf output for special characters

### DIFF
--- a/integration/spec/features/email_output_spec.rb
+++ b/integration/spec/features/email_output_spec.rb
@@ -29,7 +29,7 @@ describe 'Filling out an Email output form' do
     continue
 
     # text
-    fill_in 'cat_details', with: 'My cat is a fluffy killer'
+    fill_in 'cat_details', with: 'My cat is a fluffy killer named %'
     continue
 
     # checkbox
@@ -120,7 +120,7 @@ describe 'Filling out an Email output form' do
 
     # textarea
     expect(result).to include('Your cat')
-    expect(result).to include('My cat is a fluffy killer')
+    expect(result).to include('My cat is a fluffy killer named %')
 
     # checkbox
     expect(result).to include('Your fruit')
@@ -183,7 +183,7 @@ describe 'Filling out an Email output form' do
       'Builders',
       'yes',
       'fb-acceptance-tests@digital.justice.gov.uk',
-      'My cat is a fluffy killer',
+      'My cat is a fluffy killer named %',
       'Apples',
       'Pears',
       '2007-11-12',


### PR DESCRIPTION
This adds the checks for special characters such as %.

Also add additional testing around sub headings as they were printing the HTML tags.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>