### PR TITLE
Add tests for special characters in form submissions

### DIFF
--- a/integration/spec/features/email_output_spec.rb
+++ b/integration/spec/features/email_output_spec.rb
@@ -29,7 +29,7 @@ describe 'Filling out an Email output form' do
     continue
 
     # text
-    fill_in 'cat_details', with: 'My cat is a fluffy killer named %'
+    fill_in 'cat_details', with: 'My cat is a fluffy killer named £ % ~ ! @ # $ ^ * ( ) - _ = + [ ] | ; , . ?'
     continue
 
     # checkbox
@@ -120,7 +120,7 @@ describe 'Filling out an Email output form' do
 
     # textarea
     expect(result).to include('Your cat')
-    expect(result).to include('My cat is a fluffy killer named %')
+    expect(result).to include('My cat is a fluffy killer named £ % ~ ! @ # $ ^ * ( ) - _ = + [ ] | ; , . ?')
 
     # checkbox
     expect(result).to include('Your fruit')
@@ -183,7 +183,7 @@ describe 'Filling out an Email output form' do
       'Builders',
       'yes',
       'fb-acceptance-tests@digital.justice.gov.uk',
-      'My cat is a fluffy killer named %',
+      'My cat is a fluffy killer named £ % ~ ! @ # $ ^ * ( ) - _ = + [ ] | ; , . ?',
       'Apples',
       'Pears',
       '2007-11-12',


### PR DESCRIPTION
Card: https://trello.com/c/ARVs1ROm/1128-add-acceptance-test-testing-special-characters

Add more special characters to the existing test to ensure the application is able to handle such characters.
The `{ }` characters have not been tested as the application attempts to interpolate them into a variable.

Below is the error message we get when we attempt to add `{ }` in the text area component:
![Screenshot 2020-12-22 at 14 53 40](https://user-images.githubusercontent.com/29227502/102903019-ac6bd380-4467-11eb-88ba-db44917a6fc4.png)

The characters `" < >` have also been omitted, this is because these characters become XML entities in the generated PDF.
 
<img width="469" alt="Screenshot 2020-12-22 at 15 31 40" src="https://user-images.githubusercontent.com/29227502/102905288-ce1a8a00-446a-11eb-9b71-2a70985d64d6.png">

Note: the characters `" < >` pass in the `fb-pdf-generator` unit tests outlined here: https://github.com/ministryofjustice/fb-pdf-generator/pull/207

We will create a separate bug card to address the `{ } " < >` characters.