### PR TITLE
Temporary over night testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,3 +44,13 @@ workflows:
                 - master
     jobs:
       - clear_old_emails
+  temporary_overnight_testing:
+    triggers:
+      - schedule:
+          cron: "0 0-6 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test


### PR DESCRIPTION
We run to run the acceptance tests on the hour between midnight and 6am so that they coincide with cloud platforms node recycling jobs. This will hopefully help us see if there are communication problems between namespaces when the pods move between nodes