### PR TITLE
Add tests for new runner

### DIFF
--- a/Dockerfile.forms
+++ b/Dockerfile.forms
@@ -1,27 +1,35 @@
 FROM alpine:edge
+
+USER root
+
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+ARG UID=1001
 
 RUN apk add bash openssh git
 RUN apk add nodejs npm
 RUN apk add build-base
 RUN apk add openssl-dev ruby ruby-dev ruby-bigdecimal
 
+RUN addgroup -g ${UID} -S appgroup && \
+  adduser -u ${UID} -S appuser -G appgroup
+
 WORKDIR /app
+RUN chown appuser:appgroup /app
 
-#RUN addgroup -g ${UID} -S appgroup && \
-#  adduser -u ${UID} -S appuser -G appgroup
-#RUN chown appuser:appgroup /app
-#USER appuser
-
-COPY package.json package-lock.json forms ./
+COPY --chown=appuser:appgroup package.json package-lock.json forms ./
 
 ARG NPM_CMD='ci --ignore-optional --ignore-scripts'
 RUN npm ${NPM_CMD}
 
-COPY . .
+COPY --chown=appuser:appgroup . .
 
-RUN gem install bundler
-RUN BUNDLE_JOBS=4 bundle install --verbose
+RUN chown appuser:appgroup /app
+RUN chown appuser:appgroup /usr/lib/ruby
 
 EXPOSE 3000
+USER appuser
+
+RUN gem install bundler --user-install
+RUN BUNDLE_JOBS=4 bundle install --verbose
+
 CMD ./integration/bin/runner --start

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ endif
 
 ## Experimental ##
 spec-ci:
-	docker-compose -f docker-compose.ci.yml run integration_ci bundle exec parallel_rspec spec --exclude-pattern 'spec/features/save_and_return_module_spec.rb' -n 4
+	docker-compose -f docker-compose.ci.yml run --rm integration_ci bundle exec parallel_rspec spec --exclude-pattern 'spec/features/save_and_return_module_spec.rb' -n 4
 
 ## Clears out emails older than 24 hours from the gmail inbox that receives test submissions
 clear-emails:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
     ports:
       - 10003:3000
     environment:
+      RAILS_LOG_TO_STDOUT: 'true'
       DATABASE_URL: postgres://postgres:password@submitter-db/submitter_local
       NOTIFY_EMAIL_GENERIC: 46a72b64-9541-4000-91a7-fa8a3fa10bf9
       NOTIFY_EMAIL_RETURN_SETUP_EMAIL_TOKEN: 38f6a1cd-a810-4f59-8899-2c300236c5b4

--- a/integration/Gemfile
+++ b/integration/Gemfile
@@ -1,6 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'activesupport'
+gem 'byebug'
 gem 'capybara'
 gem 'dotenv'
 gem 'google-api-client'

--- a/integration/smoke_tests/form_spec.rb
+++ b/integration/smoke_tests/form_spec.rb
@@ -74,9 +74,7 @@ describe 'Smoke test' do
 
     form.send_application_button.click
     attachments = EmailAttachmentExtractor.find(
-      id: generated_name,
-      pdf_filename: '-answers.pdf',
-      user_attachment_filename: 'hello_world.txt'
+      id: generated_name
     )
 
     puts 'Verifying file upload'

--- a/integration/spec/features/email_output_spec.rb
+++ b/integration/spec/features/email_output_spec.rb
@@ -196,11 +196,7 @@ describe 'Filling out an Email output form' do
 
   def find_attachments(pdf_filename:, user_attachment_filename:)
     if ENV['CI_MODE'].present?
-      EmailAttachmentExtractor.find(
-        id: generated_first_name,
-        pdf_filename: pdf_filename,
-        user_attachment_filename: user_attachment_filename
-      )
+      EmailAttachmentExtractor.find(id: generated_first_name)
     else
       all_attachments = {}
 

--- a/integration/spec/features/new_runner_spec.rb
+++ b/integration/spec/features/new_runner_spec.rb
@@ -1,15 +1,17 @@
+require 'pdf-reader'
+
 describe 'New Runner' do
   let(:form) { NewRunnerApp.new }
   before :each do
     OutputRecorder.cleanup_recorded_requests if ENV['CI_MODE'].blank?
   end
-  let(:generated_first_name) { SecureRandom.uuid }
+  let(:generated_name) { "FN-#{SecureRandom.uuid}" }
 
   it 'sends an email with the submission in a PDF' do
     form.load
     form.start_button.click
     form.first_name_field.set('Stormtrooper')
-    form.last_name_field.set('FN-2187')
+    form.last_name_field.set(generated_name)
     continue
 
     form.email_field.set('fb-acceptance-tests@digital.justice.gov.uk')
@@ -41,7 +43,7 @@ describe 'New Runner' do
 
     # check your answers
     expect(page.text).to include('First name Stormtrooper')
-    expect(page.text).to include('Last name FN-2187')
+    expect(page.text).to include("Last name #{generated_name}")
     expect(page.text).to include('Your email address fb-acceptance-tests@digital.justice.gov.uk')
     expect(page.text).to include('Your cat My cat is a fluffy killer £ % ~ ! @ # $ ^ * ( ) - _ = + [ ] | ; , . ?')
     expect(page.text).to include("Your fruit Apples\nPears")
@@ -53,39 +55,35 @@ describe 'New Runner' do
 
     expect(form.text).to include("You've sent us the answers about your cat!")
 
-    attachments = find_attachments(
-      id: 'Submission from New Acceptance tests Email Output',
-      pdf_filename: '-answers.pdf',
-      user_attachment_filename: 'hello_world.txt'
-    )
+    attachments = find_attachments(id: generated_name)
 
-    assert_pdf_contents(attachments[:pdf_answers])
+    assert_pdf_contents(attachments)
   end
 
   def continue
     form.continue_button.click
   end
 
-  def parse_email(email)
-    url_decoded_hash = CGI::parse(email)
-    Mail.read_from_string(url_decoded_hash.fetch('raw_message'))
-  end
-
-  def assert_pdf_contents(attachment)
-    pdf_path = '/tmp/submission.pdf'
-
-    File.open(pdf_path, 'w') { |file| file.write(attachment) }
-    result = PDF::Reader.new(pdf_path).pages.map { |page| page.text }.join(' ')
-
+  def assert_pdf_contents(attachments)
+    pdf_path = "/tmp/submission-#{SecureRandom.uuid}.pdf"
+    File.open(pdf_path, 'w') do |file|
+      file.write(attachments[:pdf_answers])
+    end
+    result = PDF::Reader.new(pdf_path).pages.map do |page|
+      page.text
+    end.join(' ')
     p 'Asserting PDF contents'
 
     expect(result).to include('Subheading for new acceptance tests')
-    expect(result).to include('Submission for New Acceptance tests Email Output')
+    expect(result).to include(
+      "Submission for New Acceptance tests Email"
+    )
 
     # text
-    expect(result).to include('Your name')
+    # Not possible to test this at the moment as we are holding sections feature
+    # expect(result).to include('Your name')
     expect(result).to match(/First name[\n\r\s]+Stormtrooper/)
-    expect(result).to match(/Last name[\n\r\s]+FN-2187/)
+    expect(result).to match(/Last name[\n\r\s]+#{generated_name}/)
 
     # email
     expect(result).to include('Your email address')
@@ -93,7 +91,7 @@ describe 'New Runner' do
 
     # textarea
     expect(result).to include('Your cat')
-    expect(result).to include('My cat is a fluffy killer named £ % ~ ! @ # $ ^ * ( ) - _ = + [ ] | ; , . ?')
+    expect(result).to include('My cat is a fluffy killer £ % ~ ! @ # $ ^ * ( ) - _ = + [ ] | ; , . ?')
 
     # checkbox
     expect(result).to include('Your fruit')
@@ -101,44 +99,23 @@ describe 'New Runner' do
     expect(result).to include('Pears')
 
     # date
-    expect(result).to include('When did your cat choose you?')
+    expect(result).to include("When did your cat choose\n you?")
     expect(result).to include('12 November 2007')
 
     # number
-    expect(result).to include('How many cats have chosen you?')
+    expect(result).to include("How many cats have chosen\n you?")
     expect(result).to include('28')
   end
 
-  def find_attachments(id:, pdf_filename:, user_attachment_filename:)
+  def find_attachments(id:)
     if ENV['CI_MODE'].present?
       EmailAttachmentExtractor.find(
         id: id,
-        pdf_filename: pdf_filename,
-        user_attachment_filename: user_attachment_filename,
-        expected_emails: 1
+        expected_emails: 1,
+        find_criteria: :attachments
       )
     else
-      all_attachments = {}
-
-      emails = OutputRecorder.wait_for_result(url: '/email', expected_requests: 4)
-      emails[0..1].each do |email|
-        attachments = parse_email(email).attachments
-        pdf_answers = attachments.detect do |attachment|
-          attachment.filename.include?(pdf_filename)
-        end
-        file_upload = attachments.detect do |attachment|
-          attachment.filename.include?(user_attachment_filename)
-        end
-
-        all_attachments[:pdf_answers] = pdf_answers.decoded
-        all_attachments[:file_upload] = file_upload.decoded
-      end
-
-      all_attachments[:csvs] = emails[2..3].map do |email|
-        parse_email(email).attachments.map(&:decoded)
-      end.flatten
-
-      all_attachments
+      {}
     end
   end
 end

--- a/integration/spec/features/new_runner_spec.rb
+++ b/integration/spec/features/new_runner_spec.rb
@@ -1,0 +1,128 @@
+describe 'New Runner' do
+  let(:form) { NewRunnerApp.new }
+  before :each do
+    OutputRecorder.cleanup_recorded_requests if ENV['CI_MODE'].blank?
+  end
+  let(:generated_first_name) { SecureRandom.uuid }
+
+  it 'sends an email with the submission in a PDF' do
+    form.load
+    form.start_button.click
+    form.first_name_field.set('Stormtrooper')
+    form.last_name_field.set('FN-2187')
+    continue
+
+    form.email_field.set('fb-acceptance-tests@digital.justice.gov.uk')
+    continue
+
+    # text
+    fill_in 'cat_details',
+      with: 'My cat is a fluffy killer £ % ~ ! @ # $ ^ * ( ) - _ = + [ ] | ; , . ?'
+    continue
+
+    # checkbox
+    form.apples_field.check
+    form.pears_field.check
+    continue
+
+    # date
+    form.day_field.set('12')
+    form.month_field.set('11')
+    form.year_field.set('2007')
+    continue
+
+    # number
+    form.number_cats_field.set(28)
+    continue
+
+    click_on 'Accept and send application'
+
+    expect(form.text).to include("You've sent us the answers about your cat!")
+
+    attachments = find_attachments(
+      id: 'Submission for New Acceptance tests Email Output',
+      pdf_filename: '-answers.pdf',
+      user_attachment_filename: 'hello_world.txt'
+    )
+
+    assert_pdf_contents(attachments[:pdf_answers])
+  end
+
+  def continue
+    form.continue_button.click
+  end
+
+  def parse_email(email)
+    url_decoded_hash = CGI::parse(email)
+    Mail.read_from_string(url_decoded_hash.fetch('raw_message'))
+  end
+
+  def assert_pdf_contents(attachment)
+    pdf_path = '/tmp/submission.pdf'
+
+    File.open(pdf_path, 'w') { |file| file.write(attachment) }
+    result = PDF::Reader.new(pdf_path).pages.map { |page| page.text }.join(' ')
+
+    p 'Asserting PDF contents'
+
+    expect(result).to include('Submission for New Acceptance tests Email Output')
+
+    # text
+    expect(result).to include('Your name')
+    expect(result).to match(/First name[\n\r\s]+#{generated_first_name}/)
+    expect(result).to match(/Last name[\n\r\s]+Builders/)
+
+    # email
+    expect(result).to include('Your email address')
+    expect(result).to include('fb-acceptance-tests@digital.justice.gov.uk')
+
+    # textarea
+    expect(result).to include('Your cat')
+    expect(result).to include('My cat is a fluffy killer named £ % ~ ! @ # $ ^ * ( ) - _ = + [ ] | ; , . ?')
+
+    # checkbox
+    expect(result).to include('Your fruit')
+    expect(result).to include('Apples')
+    expect(result).to include('Pears')
+
+    # date
+    expect(result).to include('When did your cat choose you?')
+    expect(result).to include('12 November 2007')
+
+    # number
+    expect(result).to include('How many cats have chosen you?')
+    expect(result).to include('28')
+  end
+
+  def find_attachments(id:, pdf_filename:, user_attachment_filename:)
+    if ENV['CI_MODE'].present?
+      EmailAttachmentExtractor.find(
+        id: id,
+        pdf_filename: pdf_filename,
+        user_attachment_filename: user_attachment_filename
+      )
+    else
+      all_attachments = {}
+
+      emails = OutputRecorder.wait_for_result(url: '/email', expected_requests: 4)
+      emails[0..1].each do |email|
+        attachments = parse_email(email).attachments
+        pdf_answers = attachments.detect do |attachment|
+          attachment.filename.include?(pdf_filename)
+        end
+        file_upload = attachments.detect do |attachment|
+          attachment.filename.include?(user_attachment_filename)
+        end
+
+        all_attachments[:pdf_answers] = pdf_answers.decoded
+        all_attachments[:file_upload] = file_upload.decoded
+      end
+
+      all_attachments[:csvs] = emails[2..3].map do |email|
+        parse_email(email).attachments.map(&:decoded)
+      end.flatten
+
+      all_attachments
+    end
+  end
+end

--- a/integration/spec/features/new_runner_spec.rb
+++ b/integration/spec/features/new_runner_spec.rb
@@ -16,7 +16,7 @@ describe 'New Runner' do
     continue
 
     # text
-    fill_in 'cat_details',
+    fill_in 'Your cat',
       with: 'My cat is a fluffy killer £ % ~ ! @ # $ ^ * ( ) - _ = + [ ] | ; , . ?'
     continue
 
@@ -99,7 +99,8 @@ describe 'New Runner' do
       EmailAttachmentExtractor.find(
         id: id,
         pdf_filename: pdf_filename,
-        user_attachment_filename: user_attachment_filename
+        user_attachment_filename: user_attachment_filename,
+        expected_emails: 1
       )
     else
       all_attachments = {}

--- a/integration/spec/features/new_runner_spec.rb
+++ b/integration/spec/features/new_runner_spec.rb
@@ -35,6 +35,20 @@ describe 'New Runner' do
     form.number_cats_field.set(28)
     continue
 
+    # radio
+    form.yes_field.choose
+    continue
+
+    # check your answers
+    expect(page.text).to include('First name Stormtrooper')
+    expect(page.text).to include('Last name FN-2187')
+    expect(page.text).to include('Your email address fb-acceptance-tests@digital.justice.gov.uk')
+    expect(page.text).to include('Your cat My cat is a fluffy killer £ % ~ ! @ # $ ^ * ( ) - _ = + [ ] | ; , . ?')
+    expect(page.text).to include("Your fruit Apples\nPears")
+    expect(page.text).to include('12 November 2007')
+    expect(page.text).to include('How many cats have chosen you? 28')
+    expect(page.text).to include('Is your cat watching you now? Yes')
+
     click_on 'Accept and send application'
 
     expect(form.text).to include("You've sent us the answers about your cat!")

--- a/integration/spec/features/new_runner_spec.rb
+++ b/integration/spec/features/new_runner_spec.rb
@@ -54,7 +54,7 @@ describe 'New Runner' do
     expect(form.text).to include("You've sent us the answers about your cat!")
 
     attachments = find_attachments(
-      id: 'Submission for New Acceptance tests Email Output',
+      id: 'Submission from New Acceptance tests Email Output',
       pdf_filename: '-answers.pdf',
       user_attachment_filename: 'hello_world.txt'
     )
@@ -79,12 +79,13 @@ describe 'New Runner' do
 
     p 'Asserting PDF contents'
 
+    expect(result).to include('Subheading for new acceptance tests')
     expect(result).to include('Submission for New Acceptance tests Email Output')
 
     # text
     expect(result).to include('Your name')
-    expect(result).to match(/First name[\n\r\s]+#{generated_first_name}/)
-    expect(result).to match(/Last name[\n\r\s]+Builders/)
+    expect(result).to match(/First name[\n\r\s]+Stormtrooper/)
+    expect(result).to match(/Last name[\n\r\s]+FN-2187/)
 
     # email
     expect(result).to include('Your email address')

--- a/integration/spec/support/email_output_service/email_attachment_extractor.rb
+++ b/integration/spec/support/email_output_service/email_attachment_extractor.rb
@@ -1,18 +1,17 @@
 class EmailAttachmentExtractor
-  def self.find(id:, pdf_filename:, user_attachment_filename:, expected_emails: nil)
-    email_finder = EmailFinder.new(
-      service: GoogleService,
-      id: id,
-      pdf_filename: pdf_filename,
-      user_attachment_filename: user_attachment_filename
-    )
-
-    email_finder.expected_emails = expected_emails if expected_emails.present?
-
+  def self.find(
+    id:,
+    expected_emails: nil,
+    find_criteria: nil
+  )
     tries = 1
     max_tries = 20
 
     until tries > max_tries
+      email_finder = EmailFinder.new(id: id, service: GoogleService)
+      email_finder.expected_emails = expected_emails if expected_emails.present?
+      email_finder.find_criteria = find_criteria if find_criteria.present?
+
       if email_finder.email_received?
         break
       else
@@ -25,7 +24,9 @@ class EmailAttachmentExtractor
     if tries == max_tries || !email_finder.email_received?
       raise "Email '#{email_finder.id}' not found"
     else
-      email_finder.attachments
+      email_finder.attachments.tap do
+        email_finder.remove_emails
+      end
     end
   end
 end

--- a/integration/spec/support/email_output_service/email_attachment_extractor.rb
+++ b/integration/spec/support/email_output_service/email_attachment_extractor.rb
@@ -1,11 +1,13 @@
 class EmailAttachmentExtractor
-  def self.find(id:, pdf_filename:, user_attachment_filename:)
+  def self.find(id:, pdf_filename:, user_attachment_filename:, expected_emails: nil)
     email_finder = EmailFinder.new(
       service: GoogleService,
       id: id,
       pdf_filename: pdf_filename,
       user_attachment_filename: user_attachment_filename
     )
+
+    email_finder.expected_emails = expected_emails if expected_emails.present?
 
     tries = 1
     max_tries = 20

--- a/integration/spec/support/email_output_service/email_finder.rb
+++ b/integration/spec/support/email_output_service/email_finder.rb
@@ -4,16 +4,18 @@ class EmailFinder
   USER_ID = 'me'.freeze
 
   attr_reader :id
+  attr_accessor :expected_emails
 
-  def initialize(service:, id:, pdf_filename:, user_attachment_filename:)
+  def initialize(service:, id:, pdf_filename:, user_attachment_filename:, expected_emails: nil)
     @service = service.new.authenticated_service
     @id = id
     @pdf_filename = pdf_filename
     @user_attachment_filename = user_attachment_filename
+    @expected_emails = expected_emails || 2
   end
 
   def email_received?
-    emails.size == 2
+    emails.size == @expected_emails
   end
 
   def emails

--- a/integration/spec/support/email_output_service/email_finder.rb
+++ b/integration/spec/support/email_output_service/email_finder.rb
@@ -1,17 +1,19 @@
 require_relative 'google_service'
 
 class EmailFinder
-  USER_ID = 'me'.freeze
+  attr_accessor :id, :expected_emails, :find_criteria
 
-  attr_reader :id
-  attr_accessor :expected_emails
-
-  def initialize(service:, id:, pdf_filename:, user_attachment_filename:, expected_emails: nil)
+  def initialize(
+    service:,
+    id:,
+    expected_emails: nil,
+    find_criteria: nil
+  )
     @service = service.new.authenticated_service
     @id = id
-    @pdf_filename = pdf_filename
-    @user_attachment_filename = user_attachment_filename
+    @find_criteria = find_criteria || :subject
     @expected_emails = expected_emails || 2
+    @inbox = Inbox.new(@service)
   end
 
   def email_received?
@@ -19,51 +21,57 @@ class EmailFinder
   end
 
   def emails
-    Array(messages).map do |m|
-      message = service.get_user_message(USER_ID, m.id)
-      subject = Array(message.payload.headers).find { |h| h.name == 'Subject' }&.value
-
-      puts "Looking for subject with #{id} in #{subject}"
-      message if subject.include?(id)
-    end.compact
+    @filtered_emails ||= if find_criteria == :subject
+      all_by_subject
+    else
+      all_by_attachment
+    end
   end
 
   def attachments
-    all_attachments = { csvs: [] }
+    hash = {}
 
-    emails.map do |email|
-      email.payload.parts.each do |part|
-        next if part.filename.empty?
-
-        data = part.body.data
-        if data.blank?
-          data = service.get_user_message_attachment(
-            USER_ID,
-            email.id,
-            part.body.attachment_id
-          ).data
-        end
-
-        if part.filename.include?(pdf_filename)
-          all_attachments[:pdf_answers] = data
-        elsif part.filename.include?(user_attachment_filename)
-          all_attachments[:file_upload] = data
-        elsif part.filename.include?('.csv')
-          all_attachments[:csvs] << data
-        end
-      end
-      puts "Trashing email #{email.id}"
-      service.trash_user_message(USER_ID, email.id)
+    @filtered_emails.each do |email|
+      hash.merge!(email.attachments.reject { |_,v| v.blank? })
     end
 
-    all_attachments
+    hash
+  end
+
+  def remove_emails
+    inbox.remove_emails(@filtered_emails) if @filtered_emails.present?
   end
 
   private
 
-  def messages
-    service.list_user_messages(USER_ID).messages
+  def all_by_subject
+    inbox.all.select do |email|
+      puts "Looking for subject with #{id} in #{email.subject}"
+      email.subject.include?(id)
+    end
   end
 
-  attr_reader :service, :pdf_filename, :user_attachment_filename
+  def all_by_attachment
+    inbox.all.select do |email|
+      if email.attachments[:pdf_answers]
+        pdf_path = "/tmp/submission-#{SecureRandom.uuid}.pdf"
+        File.open(pdf_path, 'w') do |file|
+          file.write(email.attachments[:pdf_answers])
+        end
+        result = PDF::Reader.new(pdf_path).pages.map do |page|
+          page.text
+        end.join(' ')
+
+        puts "Looking for attachment with #{id} in #{email.subject}"
+        if result.include?(id)
+          puts "=" * 80
+          puts "Found in #{email.subject}! #{id}"
+          puts "=" * 80
+        end
+        result.include?(id)
+      end
+    end
+  end
+
+  attr_reader :service, :pdf_filename, :user_attachment_filename, :inbox
 end

--- a/integration/spec/support/email_output_service/inbox.rb
+++ b/integration/spec/support/email_output_service/inbox.rb
@@ -1,0 +1,72 @@
+require 'pdf-reader'
+
+class Inbox
+  USER_ID = 'me'.freeze
+  attr_reader :service
+
+  def initialize(service)
+    @service = service
+  end
+
+  def all
+    messages.map do |message|
+      email = service.get_user_message(USER_ID, message.id)
+      subject = Array(
+        email.payload.headers
+      ).find { |header| header.name == 'Subject' }&.value
+
+      AcceptanceTestEmail.new(
+        email_id: email.id,
+        subject: subject,
+        snippet: email.snippet,
+        attachments: all_attachments_for(email),
+        raw: email
+      )
+    end
+  end
+
+  def remove_emails(emails)
+    emails.each do |email|
+      service.trash_user_message(USER_ID, email.email_id)
+    end
+  end
+
+
+  private
+
+  def messages
+    Array(service.list_user_messages(USER_ID).messages)
+  end
+
+  def all_attachments_for(message)
+    all_attachments = { csvs: [], pdf_answers: nil, file_upload: nil }
+
+    return all_attachments if message.payload.blank?
+
+    message.payload.parts.each do |part|
+      next if part.filename.empty?
+
+      data = part.body.data
+      if data.blank?
+        data = service.get_user_message_attachment(
+          USER_ID,
+          message.id,
+          part.body.attachment_id
+        ).data
+      end
+
+      if part.mime_type == 'application/pdf'
+        all_attachments[:pdf_answers] = data
+      elsif part.mime_type == 'text/plain'
+        all_attachments[:file_upload] = data
+      elsif part.filename.include?('.csv')
+        all_attachments[:csvs] << data
+      end
+    end
+
+    all_attachments
+  end
+end
+
+class AcceptanceTestEmail < OpenStruct
+end

--- a/integration/spec/support/pages/new_runner_app.rb
+++ b/integration/spec/support/pages/new_runner_app.rb
@@ -1,0 +1,5 @@
+class NewRunnerApp < FeaturesEmailApp
+  set_url ENV.fetch('NEW_RUNNER_APP')
+
+  element :start_button, :button, 'Start now'
+end

--- a/integration/spec/support/pages/new_runner_app.rb
+++ b/integration/spec/support/pages/new_runner_app.rb
@@ -2,4 +2,5 @@ class NewRunnerApp < FeaturesEmailApp
   set_url ENV.fetch('NEW_RUNNER_APP')
 
   element :start_button, :button, 'Start now'
+  element :yes_field, :radio_button, 'Yes', visible: false
 end

--- a/integration/tests.env.ci
+++ b/integration/tests.env.ci
@@ -16,6 +16,7 @@ COMPONENTS_TEXTAREA_APP="https://acceptance-tests-textarea.dev.test.form.service
 COMPONENTS_UPLOAD_APP="https://acceptance-tests-upload.dev.test.form.service.justice.gov.uk/"
 COMPONENTS_UPLOAD_WITH_CONDITIONAL_APP="https://acceptance-tests-conditional-with-upload.dev.test.form.service.justice.gov.uk/"
 COMPONENTS_EXIT_PAGE_APP="https://acceptance-tests-exit-page.dev.test.form.service.justice.gov.uk/"
+NEW_RUNNER_APP="https://new-acceptance-tests-email-output.dev.test.form.service.justice.gov.uk/"
 
 ## See what to do with this env vars. The tests require this to boot
 ## but aren't needed when run in CI mode.


### PR DESCRIPTION
[Trello card](https://trello.com/c/ZoUVp1JJ/1431-acceptance-test-the-new-runner)

## Context

I added the acceptance tests for a new publish form using the new runner app (https://github.com/ministryofjustice/fb-runner).

The form is deployed under my account at the moment but now that we have an editor, duplicate this form and pointing to a new URL would be super easy!

## Caveats

The new Runner <-> Submitter V2 does not concatenate the input fields into the email so to find exactly the same email that we are submitting on the acceptance test we need to parse the attachment and find the one that has the unique identifier field value (I used the first name / last name field).

## Next steps

1. Add the acceptance tests to the runner pipeline (in case it not already there)

 
