### PR TITLE
Additional Runner V2 tests around Optional fields

### DIFF
--- a/integration/spec/features/new_runner_spec.rb
+++ b/integration/spec/features/new_runner_spec.rb
@@ -1,5 +1,12 @@
 require 'pdf-reader'
 
+OPTIONAL_TEXT = [
+  '[Optional section heading]',
+  '[Optional lede paragraph]',
+  '[Optional content]',
+  '[Optional hint text]'
+]
+
 describe 'New Runner' do
   let(:form) { NewRunnerApp.new }
   before :each do
@@ -10,45 +17,56 @@ describe 'New Runner' do
   it 'sends an email with the submission in a PDF' do
     form.load
     form.start_button.click
+
+    check_optional_text(page.text)
     form.first_name_field.set('Stormtrooper')
     form.last_name_field.set(generated_name)
     continue
 
+    check_optional_text(page.text)
     form.email_field.set('fb-acceptance-tests@digital.justice.gov.uk')
     continue
 
     # text
+    check_optional_text(page.text)
     fill_in 'Your cat',
       with: 'My cat is a fluffy killer £ % ~ ! @ # $ ^ * ( ) - _ = + [ ] | ; , . ?'
     continue
 
     # optional fields
+    check_optional_text(page.text)
     continue
 
     # checkbox
+    check_optional_text(page.text)
     form.apples_field.check
     form.pears_field.check
     continue
 
     # date
+    check_optional_text(page.text)
     form.day_field.set('12')
     form.month_field.set('11')
     form.year_field.set('2007')
     continue
 
     # number
+    check_optional_text(page.text)
     form.number_cats_field.set(28)
     continue
 
     # radio
+    check_optional_text(page.text)
     form.yes_field.choose
     continue
 
     # attach file
+    check_optional_text(page.text)
     attach_file('Upload a file', 'spec/fixtures/files/hello_world.txt')
     continue
 
     # check your answers
+    check_optional_text(page.text)
     expect(page.text).to include('First name Stormtrooper')
     expect(page.text).to include("Last name #{generated_name}")
     expect(page.text).to include('Your email address fb-acceptance-tests@digital.justice.gov.uk')
@@ -112,6 +130,7 @@ describe 'New Runner' do
     expect(result).to include('My cat is a fluffy killer £ % ~ ! @ # $ ^ * ( ) - _ = + [ ] | ; , . ?')
 
     # optional fields
+    # these are actually the question text for each component, not optional hint text
     expect(result).to include('Optional text (Optional)')
     expect(result).to include('Optional textarea (Optional)')
     expect(result).to include('Optional number (Optional)')
@@ -131,6 +150,9 @@ describe 'New Runner' do
     # number
     expect(result).to include("How many cats have chosen")
     expect(result).to include('28')
+
+    # optional text
+    check_optional_text(result)
   end
 
   def find_attachments(id:)
@@ -143,5 +165,9 @@ describe 'New Runner' do
     else
       {}
     end
+  end
+
+  def check_optional_text(text)
+    OPTIONAL_TEXT.each { |optional| expect(text).not_to include(optional) }
   end
 end

--- a/integration/spec/features/new_runner_spec.rb
+++ b/integration/spec/features/new_runner_spec.rb
@@ -13,22 +13,29 @@ describe 'New Runner' do
     OutputRecorder.cleanup_recorded_requests if ENV['CI_MODE'].blank?
   end
   let(:generated_name) { "FN-#{SecureRandom.uuid}" }
+  let(:error_message) { 'There is a problem' }
 
   it 'sends an email with the submission in a PDF' do
     form.load
     form.start_button.click
 
     check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.first_name_field.text, form.last_name_field.text])
     form.first_name_field.set('Stormtrooper')
     form.last_name_field.set(generated_name)
     continue
 
     check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.email_field.text])
     form.email_field.set('fb-acceptance-tests@digital.justice.gov.uk')
     continue
 
     # text
     check_optional_text(page.text)
+    continue
+    check_error_message(page.text, ['Your cat'])
     fill_in 'Your cat',
       with: 'My cat is a fluffy killer £ % ~ ! @ # $ ^ * ( ) - _ = + [ ] | ; , . ?'
     continue
@@ -37,14 +44,20 @@ describe 'New Runner' do
     check_optional_text(page.text)
     continue
 
+    expect(page.text).not_to include(error_message)
+
     # checkbox
     check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.find('h1').text])
     form.apples_field.check
     form.pears_field.check
     continue
 
     # date
     check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.find('h1').text])
     form.day_field.set('12')
     form.month_field.set('11')
     form.year_field.set('2007')
@@ -52,16 +65,22 @@ describe 'New Runner' do
 
     # number
     check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.find('h1').text])
     form.number_cats_field.set(28)
     continue
 
     # radio
     check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.find('h1').text])
     form.yes_field.choose
     continue
 
     # attach file
     check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.find('h1').text])
     attach_file('Upload a file', 'spec/fixtures/files/hello_world.txt')
     continue
 
@@ -169,5 +188,10 @@ describe 'New Runner' do
 
   def check_optional_text(text)
     OPTIONAL_TEXT.each { |optional| expect(text).not_to include(optional) }
+  end
+
+  def check_error_message(text, fields)
+    expect(page.text).to include(error_message)
+    fields.each { |field| expect(text).to include("Enter an answer for #{field}")}
   end
 end

--- a/integration/spec/features/new_runner_spec.rb
+++ b/integration/spec/features/new_runner_spec.rb
@@ -42,6 +42,7 @@ describe 'New Runner' do
 
     # optional fields
     check_optional_text(page.text)
+    form.find(:css, '#optional-questions_checkboxes_1').check('Celery', visible: false)
     continue
 
     expect(page.text).not_to include(error_message)
@@ -94,13 +95,21 @@ describe 'New Runner' do
     expect(page.text).to include('Optional textarea (Optional)')
     expect(page.text).to include('Optional number (Optional)')
     expect(page.text).to include('Optional radios (Optional)')
-    expect(page.text).to include('Optional checkboxes')
+    expect(page.text).to include('Celery')
     expect(page.text).to include('Optional date (Optional)')
     expect(page.text).to include("Your fruit Apples\nPears")
     expect(page.text).to include('12 November 2007')
     expect(page.text).to include('How many cats have chosen you? 28')
     expect(page.text).to include('Is your cat watching you now? Yes')
     expect(page.text).to include('Upload a file hello_world.txt')
+
+    # Checking changing an answer
+    # Also checking optional checkboxes will remove a users previous answer
+    form.change_optional_checkbox.click
+    form.find(:css, '#optional-questions_checkboxes_1').uncheck('Celery', visible: false)
+    continue
+    expect(page.text).to include('Check your answers')
+    expect(page.text).not_to include('Celery')
 
     click_on 'Accept and send application'
 

--- a/integration/spec/support/pages/new_runner_app.rb
+++ b/integration/spec/support/pages/new_runner_app.rb
@@ -3,4 +3,5 @@ class NewRunnerApp < FeaturesEmailApp
 
   element :start_button, :button, 'Start now'
   element :yes_field, :radio_button, 'Yes', visible: false
+  element :change_optional_checkbox, :link, text: 'Your answer for Optional checkboxes (Optional)', visible: false
 end


### PR DESCRIPTION
This is mostly around testing that the fix with regard to users changing optional checkbox answers is working as expected.

Also added checks for error messages that the user sees if they attempt to proceed through a form without answering a required question.

Additionally optional hint text should never appear in the runner so add tests for that too