### PR TITLE
Add v2 runner optional file upload tests

### DIFF
--- a/integration/spec/features/new_runner_spec.rb
+++ b/integration/spec/features/new_runner_spec.rb
@@ -85,6 +85,11 @@ describe 'New Runner' do
     attach_file('Upload a file', 'spec/fixtures/files/hello_world.txt')
     continue
 
+    # optional upload page to check for adding and removing files
+    check_optional_text(page.text)
+    attach_file('Optional file upload', 'spec/fixtures/files/goodbye_world.txt')
+    continue
+
     # check your answers
     check_optional_text(page.text)
     expect(page.text).to include('First name Stormtrooper')
@@ -102,14 +107,23 @@ describe 'New Runner' do
     expect(page.text).to include('How many cats have chosen you? 28')
     expect(page.text).to include('Is your cat watching you now? Yes')
     expect(page.text).to include('Upload a file hello_world.txt')
+    expect(page.text).to include('Optional file upload (Optional) goodbye_world.txt')
 
-    # Checking changing an answer
+    # Checking changing answer for optional checkboxes
     # Also checking optional checkboxes will remove a users previous answer
     form.change_optional_checkbox.click
     form.find(:css, '#optional-questions_checkboxes_1').uncheck('Celery', visible: false)
     continue
     expect(page.text).to include('Check your answers')
     expect(page.text).not_to include('Celery')
+
+    # Checking removing file for optional file upload
+    form.change_optional_file_upload.click
+    form.remove_file.click
+    continue
+    expect(page.text).to include('Check your answers')
+    expect(page.text).to include('Optional file upload (Optional)')
+    expect(page.text).not_to include('goodbye_world.text')
 
     click_on 'Accept and send application'
 
@@ -178,6 +192,14 @@ describe 'New Runner' do
     # number
     expect(result).to include("How many cats have chosen")
     expect(result).to include('28')
+
+    # file upload
+    expect(result).to include('Upload a file')
+    expect(result).to include('hello_world.txt')
+
+    # optional file upload
+    expect(result).to include('Optional file upload')
+    expect(result).not_to include('goodbye_world.text')
 
     # optional text
     check_optional_text(result)

--- a/integration/spec/fixtures/files/goodbye_world.txt
+++ b/integration/spec/fixtures/files/goodbye_world.txt
@@ -1,0 +1,1 @@
+goodbye world

--- a/integration/spec/support/pages/new_runner_app.rb
+++ b/integration/spec/support/pages/new_runner_app.rb
@@ -4,4 +4,6 @@ class NewRunnerApp < FeaturesEmailApp
   element :start_button, :button, 'Start now'
   element :yes_field, :radio_button, 'Yes', visible: false
   element :change_optional_checkbox, :link, text: 'Your answer for Optional checkboxes (Optional)', visible: false
+  element :change_optional_file_upload, :link, text: 'Your answer for Optional file upload (Optional)', visible: false
+  element :remove_file, :link, text: 'Remove file'
 end


### PR DESCRIPTION
This checks whether it's possible for a user to add a file and then
remove it and that the file name does not exist on the check your
answers page or the generated PDF.