### PR TITLE
Require FeaturesEmailApp in spec helper

### DIFF
--- a/integration/spec/spec_helper.rb
+++ b/integration/spec/spec_helper.rb
@@ -36,6 +36,7 @@ RSpec.configure do |c|
   end
 
   require File.join(File.dirname(__FILE__), 'support', 'service_app')
+  require File.join(File.dirname(__FILE__), 'support', 'pages', 'features_email_app')
   Dir[
     File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))
   ].each { |f| require f }


### PR DESCRIPTION
It is possible that there is a requiring order issue which causes the
features email app to not have been required before the new runner app
which inherits from it.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>