### PR TITLE
Remove overnight test runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,13 +44,3 @@ workflows:
                 - master
     jobs:
       - clear_old_emails
-  temporary_overnight_testing:
-    triggers:
-      - schedule:
-          cron: "0 0-6 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - test


### PR DESCRIPTION
We know that we consistently lose network connections during node
recycling. Currently there is nothing else we can do around this. There
is no point to keep these running as no further data will be gathered.