### PR TITLE
Add acceptance tests for a form with branching

### DIFF
--- a/integration/spec/features/v2/new_runner_branching_spec.rb
+++ b/integration/spec/features/v2/new_runner_branching_spec.rb
@@ -1,0 +1,155 @@
+require 'pdf-reader'
+
+describe 'New Runner Branching App' do
+  let(:form) { NewRunnerBranchingApp.new }
+  before :each do
+    # OutputRecorder.cleanup_recorded_requests if ENV['CI_MODE'].blank?
+  end
+  let(:page_a_answer) { "FN-#{SecureRandom.uuid}" }
+  let(:page_b_answer) { 'Option 1' }
+  let(:page_b_changed_answer) { 'Option 2' }
+  let(:page_c_answer) { "FN-#{SecureRandom.uuid}" }
+  let(:page_d_answer) { "FN-#{SecureRandom.uuid}" }
+  let(:page_e_answer) { "FN-#{SecureRandom.uuid}" }
+  let(:page_f_answer) { 'Option B' }
+  let(:page_l_answer) { "FN-#{SecureRandom.uuid}" }
+  let(:page_i_answer) { 'Option 1' }
+  let(:page_j_answer) { 'Option 2' }
+  let(:page_j_changed_answer) { 'Option 3' }
+  let(:error_message) { 'There is a problem' }
+
+  it 'navigates the form and changes answers' do
+    form.load
+    form.start_button.click
+
+    # page-a
+    check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.page_a_field.text])
+    form.page_a_field.set(page_a_answer)
+    continue
+
+    # page-b
+    check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.find('h1').text])
+    form.option_1.check
+    continue
+
+    # page-c
+    check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.page_c_field.text])
+    form.page_c_field.set(page_c_answer)
+    continue
+
+    # page-d
+    check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.page_d_field.text])
+    form.page_d_field.set(page_d_answer)
+    continue
+
+    # page-e
+    check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.page_e_field.text])
+    form.page_e_field.set(page_e_answer)
+    continue
+
+    # page-f
+    check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.find('h1').text])
+    form.option_b.check
+    continue
+
+    # page-l
+    check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.page_l_field.text])
+    form.page_l_field.set(page_l_answer)
+    continue
+
+    # check your answers
+    check_optional_text(page.text)
+    expect(page_answer('Page A')).to include(page_a_answer)
+    expect(page_answer('Page B')).to include(page_b_answer)
+    expect(page_answer('Page C')).to include(page_c_answer)
+    expect(page_answer('Page D')).to include(page_d_answer)
+    expect(page_answer('Page E')).to include(page_e_answer)
+    expect(page_answer('Page F')).to include(page_f_answer)
+    expect(page_answer('Page L')).to include(page_l_answer)
+
+    # change page b answer
+    form.change_page_b_answer.click
+    form.option_1.uncheck
+    form.option_2.check
+    continue
+
+    # page-i
+    check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.find('h1').text])
+    form.option_1.check
+    continue
+
+    # page-j
+    check_optional_text(page.text)
+    continue
+    check_error_message(page.text, [form.find('h1').text])
+    form.option_2.check
+    continue
+
+    # check your answers
+    check_optional_text(page.text)
+    expect(page_answer('Page A')).to include(page_a_answer)
+    expect(page_answer('Page B')).to include(page_b_changed_answer)
+    expect(page_answer('Page I')).to include(page_i_answer)
+    expect(page_answer('Page J')).to include(page_j_answer)
+    # Old answers from different path should no longer be there
+    expect(page.text).not_to include(page_c_answer)
+    expect(page.text).not_to include(page_d_answer)
+    expect(page.text).not_to include(page_e_answer)
+    expect(page.text).not_to include(page_f_answer)
+    expect(page.text).not_to include(page_l_answer)
+
+    # change page j answer
+    form.change_page_j_answer.click
+    form.option_2.uncheck
+    form.option_3.check
+    continue
+
+    # page f
+    continue
+
+    # page l
+    continue
+
+    # check your answers should remember previously answered questions
+    check_optional_text(page.text)
+    expect(page_answer('Page A')).to include(page_a_answer)
+    expect(page_answer('Page B')).to include(page_b_changed_answer)
+    expect(page_answer('Page I')).to include(page_i_answer)
+    expect(page_answer('Page J')).to include(page_j_changed_answer)
+    expect(page_answer('Page F')).to include(page_f_answer)
+    expect(page_answer('Page L')).to include(page_l_answer)
+    # does not include older answers from different path
+    expect(page.text).not_to include(page_c_answer)
+    expect(page.text).not_to include(page_d_answer)
+    expect(page.text).not_to include(page_e_answer)
+
+    click_on 'Accept and send application'
+
+    expect(form.text).to include('Application complete')
+  end
+
+  def summary_list
+    page.all('.govuk-summary-list .govuk-summary-list__row')
+  end
+
+  def page_answer(page_key)
+    answer = summary_list.find { |row| row.find('dt.govuk-summary-list__key').text == page_key }
+    answer.find('dd.govuk-summary-list__value').text
+  end
+end

--- a/integration/spec/features/v2/new_runner_spec.rb
+++ b/integration/spec/features/v2/new_runner_spec.rb
@@ -1,12 +1,5 @@
 require 'pdf-reader'
 
-OPTIONAL_TEXT = [
-  '[Optional section heading]',
-  '[Optional lede paragraph]',
-  '[Optional content]',
-  '[Optional hint text]'
-]
-
 describe 'New Runner' do
   let(:form) { NewRunnerApp.new }
   before :each do
@@ -136,9 +129,6 @@ describe 'New Runner' do
     expect(attachments[:file_upload]).to eq(File.read('spec/fixtures/files/hello_world.txt'))
   end
 
-  def continue
-    form.continue_button.click
-  end
 
   def assert_pdf_contents(attachments)
     pdf_path = "/tmp/submission-#{SecureRandom.uuid}.pdf"
@@ -218,14 +208,5 @@ describe 'New Runner' do
     else
       {}
     end
-  end
-
-  def check_optional_text(text)
-    OPTIONAL_TEXT.each { |optional| expect(text).not_to include(optional) }
-  end
-
-  def check_error_message(text, fields)
-    expect(page.text).to include(error_message)
-    fields.each { |field| expect(text).to include("Enter an answer for #{field}")}
   end
 end

--- a/integration/spec/spec_helper.rb
+++ b/integration/spec/spec_helper.rb
@@ -41,3 +41,23 @@ RSpec.configure do |c|
     File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))
   ].each { |f| require f }
 end
+
+OPTIONAL_TEXT = [
+  '[Optional section heading]',
+  '[Optional lede paragraph]',
+  '[Optional content]',
+  '[Optional hint text]'
+]
+
+def check_optional_text(text)
+  OPTIONAL_TEXT.each { |optional| expect(text).not_to include(optional) }
+end
+
+def check_error_message(text, fields)
+  expect(page.text).to include(error_message)
+  fields.each { |field| expect(text).to include("Enter an answer for #{field}")}
+end
+
+def continue
+  form.continue_button.click
+end

--- a/integration/spec/support/pages/new_runner_branching_app.rb
+++ b/integration/spec/support/pages/new_runner_branching_app.rb
@@ -1,0 +1,23 @@
+class NewRunnerBranchingApp < ServiceApp
+  set_url ENV.fetch('NEW_RUNNER_BRANCHING_APP')
+
+  element :page_a_field, :field, 'Page A'
+
+  element :option_1, :checkbox, 'Option 1', visible: false
+  element :option_2, :checkbox, 'Option 2', visible: false
+  element :option_3, :checkbox, 'Option 3', visible: false
+
+  element :page_c_field, :field, 'Page C'
+  element :page_d_field, :field, 'Page D'
+  element :page_e_field, :field, 'Page E'
+
+  element :option_a, :checkbox, 'Option A', visible: false
+  element :option_b, :checkbox, 'Option B', visible: false
+  element :option_c, :checkbox, 'Option C', visible: false
+  element :option_d, :checkbox, 'Option D', visible: false
+
+  element :page_l_field, :field, 'Page L'
+
+  element :change_page_b_answer, :link, text: 'Your answer for Page B', visible: false
+  element :change_page_j_answer, :link, text: 'Your answer for Page J', visible: false
+end

--- a/integration/tests.env.ci
+++ b/integration/tests.env.ci
@@ -17,6 +17,7 @@ COMPONENTS_UPLOAD_APP="https://acceptance-tests-upload.dev.test.form.service.jus
 COMPONENTS_UPLOAD_WITH_CONDITIONAL_APP="https://acceptance-tests-conditional-with-upload.dev.test.form.service.justice.gov.uk/"
 COMPONENTS_EXIT_PAGE_APP="https://acceptance-tests-exit-page.dev.test.form.service.justice.gov.uk/"
 NEW_RUNNER_APP="https://new-runner-acceptance-tests.dev.test.form.service.justice.gov.uk/"
+NEW_RUNNER_BRANCHING_APP="https://acceptance-tests-branching-fixture-10.dev.test.form.service.justice.gov.uk/"
 
 ## See what to do with this env vars. The tests require this to boot
 ## but aren't needed when run in CI mode.


### PR DESCRIPTION
This adds the acceptance tests for a form which has branching logic in
it.

The tests do not currently test the pdf generated. That will be added in
a separate PR.