### PR TITLE
Cooke banner acceptance tests

### DIFF
--- a/integration/spec/features/cookies_banner_spec.rb
+++ b/integration/spec/features/cookies_banner_spec.rb
@@ -1,0 +1,39 @@
+require 'capybara/rspec'
+require 'spec_helper'
+require 'httparty'
+
+describe 'Interacting with cookie banner' do
+  context 'accepting analytics' do
+    let(:form) { ComponentsNumberApp.new }
+    let(:cookie_banner_text) { 'Cookies on Number Acceptance Test Service' }
+    let(:cookie_accepted_text) { "You've accepted analytics cookies" }
+
+    it 'shows the cookie banner and accepted message' do
+      form.load
+      expect(form.text).to include(cookie_banner_text)
+
+      form.accept_analytics.click
+      expect(form.text).to include(cookie_accepted_text)
+
+      form.hide_cookie_message.click
+      expect(form.text).not_to include(cookie_accepted_text)
+    end
+  end
+
+  context 'rejecting analytics' do
+    let(:form) { ComponentsDateApp.new }
+    let(:cookie_banner_text) { 'Cookies on Date Acceptance Test Service' }
+    let(:cookie_rejected_text) { "You've rejected analytics cookies" }
+
+    it 'shows the cookie banner and rejected message' do
+      form.load
+      expect(form.text).to include(cookie_banner_text)
+
+      form.reject_analytics.click
+      expect(form.text).to include(cookie_rejected_text)
+
+      form.hide_cookie_message.click
+      expect(form.text).not_to include(cookie_rejected_text)
+    end
+  end
+end

--- a/integration/spec/support/service_app.rb
+++ b/integration/spec/support/service_app.rb
@@ -6,6 +6,9 @@ class ServiceApp < SitePrism::Page
   elements :change_links, '.govuk-summary-list__actions a.govuk-link'
   element :send_application_button, :button, 'Accept and send application'
   element :confirmation_header, 'h1.govuk-panel__title'
+  element :accept_analytics, :button, 'Accept analytics cookies'
+  element :reject_analytics, :button, 'Reject analytics cookies'
+  element :hide_cookie_message, :button, 'Hide this message'
 
   def load(expansion_or_html = {}, &block)
     puts "Visiting form: #{self.url}"


### PR DESCRIPTION
This adds tests to check the existence of the cookie banner and
interaction with it.