### PR TITLE
Update Runner v2 acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ ci-env-vars:
 	cp integration/tests.env.ci integration/tests.env
 
 ## Experimental ##
-start-ci: ci-env-vars ci-google-envars
+start-ci: ci-env-vars ci-google-envars new-runner-acceptance-test-env-vars
 	docker-compose -f docker-compose.ci.yml up -d --build integration_ci
 
 setup-ci: start-ci
@@ -151,3 +151,7 @@ smoke-tests: ci-env-vars smoke-test-env-vars ci-google-envars
 smoke-tests-v2: ci-env-vars smoke-test-env-vars ci-google-envars
 	docker-compose -f docker-compose.ci.yml up -d --build integration_ci
 	docker-compose -f docker-compose.ci.yml run integration_ci bundle exec rspec smoke_tests_v2/form_spec.rb
+
+new-runner-acceptance-test-env-vars:
+	echo "NEW_RUNNER_ACCEPTANCE_TEST_USER=${NEW_RUNNER_ACCEPTANCE_TEST_USER}" >> ./integration/tests.env
+	echo "NEW_RUNNER_ACCEPTANCE_TEST_PASSWORD=${NEW_RUNNER_ACCEPTANCE_TEST_PASSWORD}" >> ./integration/tests.env

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ The following environment variables need to be set in order to authorize against
 
 Credentials for interacting with the Gmail API are refreshed each time the test suite is run.
 
+The following environment variables are saved in each platform app on CircleCI:
+- SMOKE_TEST_USER
+- SMOKE_TEST_PASSWORD
+- NEW_RUNNER_ACCEPTANCE_TEST_USER
+- NEW_RUNNER_ACCEPTANCE_TEST_PASSWORD
+
 The tests run against forms published to the `test-dev` environment. Currently these are:
 
 Features:

--- a/integration/spec/features/v2/new_runner_branching_spec.rb
+++ b/integration/spec/features/v2/new_runner_branching_spec.rb
@@ -2,9 +2,8 @@ require 'pdf-reader'
 
 describe 'New Runner Branching App' do
   let(:form) { NewRunnerBranchingApp.new }
-  before :each do
-    # OutputRecorder.cleanup_recorded_requests if ENV['CI_MODE'].blank?
-  end
+  let(:username) { ENV['NEW_RUNNER_ACCEPTANCE_TEST_USER'] }
+  let(:password) { ENV['NEW_RUNNER_ACCEPTANCE_TEST_PASSWORD'] }
   let(:page_a_answer) { "FN-#{SecureRandom.uuid}" }
   let(:page_b_answer) { 'Page B Option 1' }
   let(:page_b_changed_answer) { 'Page B Option 2' }
@@ -17,8 +16,9 @@ describe 'New Runner Branching App' do
   let(:page_j_answer) { 'Page J Option 2' }
   let(:error_message) { 'There is a problem' }
 
+  before { form.load }
+
   it 'navigates the form, changes answers and submits' do
-    form.load
     form.start_button.click
 
     # page-a

--- a/integration/spec/features/v2/new_runner_spec.rb
+++ b/integration/spec/features/v2/new_runner_spec.rb
@@ -1,15 +1,18 @@
 require 'pdf-reader'
 
 describe 'New Runner' do
-  let(:form) { NewRunnerApp.new }
   before :each do
     OutputRecorder.cleanup_recorded_requests if ENV['CI_MODE'].blank?
   end
+  let(:form) { NewRunnerApp.new }
+  let(:username) { ENV['NEW_RUNNER_ACCEPTANCE_TEST_USER'] }
+  let(:password) { ENV['NEW_RUNNER_ACCEPTANCE_TEST_PASSWORD'] }
   let(:generated_name) { "FN-#{SecureRandom.uuid}" }
   let(:error_message) { 'There is a problem' }
 
+  before { form.load }
+
   it 'sends an email with the submission in a PDF' do
-    form.load
     form.start_button.click
 
     check_optional_text(page.text)

--- a/integration/spec/support/pages/new_runner_app.rb
+++ b/integration/spec/support/pages/new_runner_app.rb
@@ -1,5 +1,8 @@
 class NewRunnerApp < FeaturesEmailApp
-  set_url ENV.fetch('NEW_RUNNER_APP')
+  set_url "#{ENV.fetch('NEW_RUNNER_APP')}" % {
+    user: ENV.fetch('NEW_RUNNER_ACCEPTANCE_TEST_USER'),
+    password: ENV.fetch('NEW_RUNNER_ACCEPTANCE_TEST_PASSWORD')
+  }
 
   element :start_button, :button, 'Start now'
   element :yes_field, :radio_button, 'Yes', visible: false
@@ -11,4 +14,9 @@ class NewRunnerApp < FeaturesEmailApp
   element :change_email, :link, text: 'Your answer for Your email address', visible: false
   element :change_cat, :link, text: 'Your answer for Your cat', visible: false
   element :change_upload, :link, text: 'Your answer for Upload a file', visible: false
+
+  def load(expansion_or_html = {}, &block)
+    puts "Visiting form: #{ENV['NEW_RUNNER_APP'] % { user: '*****', password: '*****' }}"
+    SitePrism::Page.instance_method(:load).bind(self).call
+  end
 end

--- a/integration/spec/support/pages/new_runner_branching_app.rb
+++ b/integration/spec/support/pages/new_runner_branching_app.rb
@@ -1,5 +1,8 @@
 class NewRunnerBranchingApp < ServiceApp
-  set_url ENV.fetch('NEW_RUNNER_BRANCHING_APP')
+  set_url "#{ENV.fetch('NEW_RUNNER_BRANCHING_APP')}" % {
+    user: ENV.fetch('NEW_RUNNER_ACCEPTANCE_TEST_USER'),
+    password: ENV.fetch('NEW_RUNNER_ACCEPTANCE_TEST_PASSWORD')
+  }
 
   element :page_a_field, :field, 'Page A'
 
@@ -20,4 +23,9 @@ class NewRunnerBranchingApp < ServiceApp
 
   element :change_page_b_answer, :link, text: 'Your answer for Page B', visible: false
   element :change_page_j_answer, :link, text: 'Your answer for Page J', visible: false
+
+  def load(expansion_or_html = {}, &block)
+    puts "Visiting form: #{ENV['NEW_RUNNER_BRANCHING_APP'] % { user: '*****', password: '*****' }}"
+    SitePrism::Page.instance_method(:load).bind(self).call
+  end
 end

--- a/integration/tests.env.ci
+++ b/integration/tests.env.ci
@@ -16,8 +16,8 @@ COMPONENTS_TEXTAREA_APP="https://acceptance-tests-textarea.dev.test.form.service
 COMPONENTS_UPLOAD_APP="https://acceptance-tests-upload.dev.test.form.service.justice.gov.uk/"
 COMPONENTS_UPLOAD_WITH_CONDITIONAL_APP="https://acceptance-tests-conditional-with-upload.dev.test.form.service.justice.gov.uk/"
 COMPONENTS_EXIT_PAGE_APP="https://acceptance-tests-exit-page.dev.test.form.service.justice.gov.uk/"
-NEW_RUNNER_APP="https://new-runner-acceptance-tests.dev.test.form.service.justice.gov.uk/"
-NEW_RUNNER_BRANCHING_APP="https://acceptance-tests-branching-fixture-10.dev.test.form.service.justice.gov.uk/"
+NEW_RUNNER_APP="https://%{user}:%{password}@new-runner-acceptance-tests.dev.test.form.service.justice.gov.uk/"
+NEW_RUNNER_BRANCHING_APP="https://%{user}:%{password}@acceptance-tests-branching-fixture-10.dev.test.form.service.justice.gov.uk/"
 
 ## See what to do with this env vars. The tests require this to boot
 ## but aren't needed when run in CI mode.


### PR DESCRIPTION
[Trello](https://trello.com/c/k5EntNtE/2501-threat-form-published-to-test-is-missing-basic-auth-m)

Add credentials to runner v2 forms, now that the editor test forms require authentication on publish.