### PR TITLE
Fix smoke tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,11 +144,11 @@ smoke-test-env-vars:
 	echo "SMOKE_TEST_USER=${SMOKE_TEST_USER}" >> ./integration/tests.env
 	echo "SMOKE_TEST_PASSWORD=${SMOKE_TEST_PASSWORD}" >> ./integration/tests.env
 
-smoke-tests: ci-env-vars smoke-test-env-vars ci-google-envars
+smoke-tests: ci-env-vars smoke-test-env-vars ci-google-envars new-runner-acceptance-test-env-vars
 	docker-compose -f docker-compose.ci.yml up -d --build integration_ci
 	docker-compose -f docker-compose.ci.yml run integration_ci bundle exec rspec smoke_tests/form_spec.rb
 
-smoke-tests-v2: ci-env-vars smoke-test-env-vars ci-google-envars
+smoke-tests-v2: ci-env-vars smoke-test-env-vars ci-google-envars new-runner-acceptance-test-env-vars
 	docker-compose -f docker-compose.ci.yml up -d --build integration_ci
 	docker-compose -f docker-compose.ci.yml run integration_ci bundle exec rspec smoke_tests_v2/form_spec.rb
 


### PR DESCRIPTION
In some projects, the smoke tests are called without the `make setup-ci` call.
This means the runner acceptance test env vars are not set and causes the tests to fail.
This commit sets the runner acceptance test env vars in the smoke test commands.
[CircleCI run](https://app.circleci.com/pipelines/github/ministryofjustice/fb-acceptance-tests/4585/workflows/045050c7-5bc1-4005-8ad0-d89cd3cc97c1/jobs/5161)