### PR TITLE
Allow smoke tests to run without new runner app env vars

### DIFF
--- a/integration/spec/support/pages/new_runner_app.rb
+++ b/integration/spec/support/pages/new_runner_app.rb
@@ -1,7 +1,7 @@
 class NewRunnerApp < FeaturesEmailApp
-  set_url "#{ENV.fetch('NEW_RUNNER_APP')}" % {
-    user: ENV.fetch('NEW_RUNNER_ACCEPTANCE_TEST_USER'),
-    password: ENV.fetch('NEW_RUNNER_ACCEPTANCE_TEST_PASSWORD')
+  set_url "#{ENV['NEW_RUNNER_APP']}" % {
+    user: ENV['NEW_RUNNER_ACCEPTANCE_TEST_USER'],
+    password: ENV['NEW_RUNNER_ACCEPTANCE_TEST_PASSWORD']
   }
 
   element :start_button, :button, 'Start now'

--- a/integration/spec/support/pages/new_runner_branching_app.rb
+++ b/integration/spec/support/pages/new_runner_branching_app.rb
@@ -1,7 +1,7 @@
 class NewRunnerBranchingApp < ServiceApp
-  set_url "#{ENV.fetch('NEW_RUNNER_BRANCHING_APP')}" % {
-    user: ENV.fetch('NEW_RUNNER_ACCEPTANCE_TEST_USER'),
-    password: ENV.fetch('NEW_RUNNER_ACCEPTANCE_TEST_PASSWORD')
+  set_url "#{ENV['NEW_RUNNER_BRANCHING_APP']}" % {
+    user: ENV['NEW_RUNNER_ACCEPTANCE_TEST_USER'],
+    password: ENV['NEW_RUNNER_ACCEPTANCE_TEST_PASSWORD']
   }
 
   element :page_a_field, :field, 'Page A'


### PR DESCRIPTION
Replace `ENV.fetch` calls with `ENV[]` in runner acceptance tests.
These env vars are not required in the smoke tests, however, with the `fetch` call, the app throws an error when attempting to run the smoke tests.
Using `ENV[]` means these will fail silently allowing the smoke tests to continue running.