### PR TITLE
Runner V2 Autocomplete component

### DIFF
--- a/integration/spec/features/v2/new_runner_spec.rb
+++ b/integration/spec/features/v2/new_runner_spec.rb
@@ -121,6 +121,15 @@ describe 'New Runner' do
     attach_file('Optional file upload', 'spec/fixtures/files/goodbye_world.txt')
     continue
 
+    # autocomplete
+    check_optional_text(page.text)
+    form.autocomplete_countries_field.set("Wonderland\n")
+    continue
+    check_error_message(page.text, [form.find('h1').text])
+    form.autocomplete_countries_field.set("Na")
+    find('li.autocomplete__option', text: 'Narnia').click
+    continue
+
     # check your answers
     check_optional_text(page.text)
     expect(page.text).to include('First name Stormtrooper')
@@ -139,6 +148,7 @@ describe 'New Runner' do
     expect(page.text).to include('Is your cat watching you now? Yes')
     expect(page.text).to include('Upload a file hello_world.txt')
     expect(page.text).to include('Optional file upload (Optional) goodbye_world.txt')
+    expect(page.text).to include('Narnia')
 
     # Checking changing answer for optional checkboxes
     # Also checking optional checkboxes will remove a users previous answer
@@ -155,6 +165,14 @@ describe 'New Runner' do
     expect(page.text).to include('Check your answers')
     expect(page.text).to include('Optional file upload (Optional)')
     expect(page.text).not_to include('goodbye_world.text')
+
+    # Check changing answer for autocomplete component
+    form.change_autocomplete.click
+    form.autocomplete_countries_field.set("W")
+    find('li.autocomplete__option', text: 'Wakanda').click
+    continue
+    expect(page.text).to include('Check your answers')
+    expect(page.text).not_to include('Narnia')
 
     form.submit_button.click
 
@@ -235,6 +253,11 @@ describe 'New Runner' do
     expect(result).to include('Optional file upload')
     expect(result).not_to include('goodbye_world.text')
 
+    # autocomplete
+    expect(result).to include('Where do you like to')
+    expect(result).to include('holiday?')
+    expect(result).to include('WK')
+
     # optional text
     check_optional_text(result)
   end
@@ -268,6 +291,7 @@ describe 'New Runner' do
       'watch_radios_1',
       'file-upload_upload_1',
       'optional-file-upload_upload_1',
+      'countries_autocomplete_1'
       ])
 
     expect(rows[1][0]).to match(/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/) # guid
@@ -288,7 +312,8 @@ describe 'New Runner' do
       '5',
       'Yes',
       'hello_world.txt',
-      ''
+      '',
+      'WK'
     ])
   end
 end

--- a/integration/spec/features/v2/scripting_spec.rb
+++ b/integration/spec/features/v2/scripting_spec.rb
@@ -52,6 +52,11 @@ describe 'New Runner' do
     # optional upload page to check for adding and removing files
     continue
 
+    # autocomplete
+    form.autocomplete_countries_field.set("Na")
+    find('li.autocomplete__option', text: 'Narnia').click
+    continue
+
     # check your answers
     form.change_first_name.click
     expect(alert_present?).to be_falsey

--- a/integration/spec/support/pages/new_runner_app.rb
+++ b/integration/spec/support/pages/new_runner_app.rb
@@ -14,6 +14,8 @@ class NewRunnerApp < FeaturesEmailApp
   element :change_email, :link, text: 'Your answer for Your email address', visible: false
   element :change_cat, :link, text: 'Your answer for Your cat', visible: false
   element :change_upload, :link, text: 'Your answer for Upload a file', visible: false
+  element :change_autocomplete, :link, text: 'Where do you like to holiday?', visible: false
+  element :autocomplete_countries_field, :field, 'Where do you like to holiday?'
 
   def load(expansion_or_html = {}, &block)
     puts "Visiting form: #{ENV['NEW_RUNNER_APP'] % { user: '*****', password: '*****' }}"


### PR DESCRIPTION
[Trello](https://trello.com/c/0oRWg4Zw/2753-autocomplete-runner-acceptance-tests)

Add acceptance tests for V2 runner, tests include:
- Validation for blank input or input that is not a valid option
- Correct input and correct text on check answers page
- Changing autocomplete answer
- Correct text on the CSV/PDF outputs