### PR TITLE
Update new runner acceptance test with reference payment feature

### DIFF
--- a/integration/spec/features/v2/new_runner_branching_spec.rb
+++ b/integration/spec/features/v2/new_runner_branching_spec.rb
@@ -143,7 +143,7 @@ describe 'New Runner Branching App' do
 
     expect(form.text).to include('Application complete')
 
-    pdf_attachments = find_pdf_attachments(id: page_a_answer)
+    pdf_attachments = find_pdf_attachments(id: page_a_answer, expected_emails: 1)
     csv_attachments = find_csv_attachments(id: page_a_answer)
     assert_pdf_contents(pdf_attachments)
     assert_csv_contents(csv_attachments)

--- a/integration/spec/features/v2/scripting_spec.rb
+++ b/integration/spec/features/v2/scripting_spec.rb
@@ -12,9 +12,10 @@ describe 'New Runner' do
     continue
 
     form.email_field.set(script)
+    form.email_field.set('name@example.com')
     continue
 
-    # text
+    # textarea
     fill_in 'Your cat',
       with: script
     continue

--- a/integration/spec/spec_helper.rb
+++ b/integration/spec/spec_helper.rb
@@ -66,11 +66,11 @@ def continue
   form.continue_button.click
 end
 
-def find_pdf_attachments(id:)
+def find_pdf_attachments(id:, expected_emails:)
   if ENV['CI_MODE'].present?
     EmailAttachmentExtractor.find(
       id: id,
-      expected_emails: 1,
+      expected_emails: expected_emails,
       find_criteria: :pdf_attachments
     )
   else


### PR DESCRIPTION
### Update new runner acceptance test with reference payment feature
Now that we have the features confirmation email, reference number and payment link, we need to ensure the Runner presents these features correctly.

The `new-runner-acceptance-test` form has been adjusted to enable confirmation email, reference number and payment link. This commit adjusts the `NewRunner` spec, to reflect this adjustment.
We check the confirmation page styling has changed, we also capture the `reference_number` on this page to be used later to check the correct email (with pdf and csv) attachments were sent on form submission.

Changes to the `find_pdf_attachments` method were made to allow us to pass in the argument `expected_emails`, as we should expect 2 in the inbox if Confirmation email is enabled, but only one if it is not (as is the case for the `new_runner_branching` spec.

### Provide an answer that passes email validation in the scripting spec
We have changed the email address question from type `text` to type `email`  to enable the confirmation email feature.

So we will now need to provide a valid email address for this page to ensure we do not trigger the validation and allow us to move onto the next question.