### PR TITLE
Add test to check reply-to address is set and service name is present

### DIFF
--- a/integration/spec/features/v2/new_runner_spec.rb
+++ b/integration/spec/features/v2/new_runner_spec.rb
@@ -182,9 +182,13 @@ describe 'New Runner' do
     expect(page.text).to include('Your reference number is:')
     expect(page.text).to include(reference_number)
 
+    confirmation_email = get_confirmation_email(reference_number)
+
+    expect(confirmation_email[0].reply_to).to include('fb-acceptance-tests+reply-to@digital.justice.gov.uk')
+    expect(confirmation_email[0].from).to include('new-runner-acceptance-tests')
+
     pdf_attachments = find_pdf_attachments(id: reference_number, expected_emails: 2)
     csv_attachments = find_csv_attachments(id: reference_number)
-
 
     assert_pdf_contents(pdf_attachments, reference_number)
     assert_csv_contents(csv_attachments, reference_number)
@@ -192,6 +196,11 @@ describe 'New Runner' do
     expect(pdf_attachments[:file_upload]).to eq(File.read('spec/fixtures/files/hello_world.txt'))
   end
 
+  def get_confirmation_email(reference_number)
+    find_email_by_subject(id: reference_number).select do |email|
+      email.subject.include?('Confirmation email')
+    end
+  end
 
   def assert_pdf_contents(attachments, reference_number)
     pdf_path = "/tmp/submission-#{SecureRandom.uuid}.pdf"

--- a/integration/spec/spec_helper.rb
+++ b/integration/spec/spec_helper.rb
@@ -71,6 +71,19 @@ def continue
   form.continue_button.click
 end
 
+def find_email_by_subject(id:)
+  if ENV['CI_MODE'].present?
+    EmailAttachmentExtractor.find(
+      id: id,
+      expected_emails: 3,
+      find_criteria: :subject,
+      include_whole_email: true
+    )
+  else
+    {}
+  end
+end
+
 def find_pdf_attachments(id:, expected_emails:)
   if ENV['CI_MODE'].present?
     EmailAttachmentExtractor.find(

--- a/integration/spec/support/email_output_service/email_attachment_extractor.rb
+++ b/integration/spec/support/email_output_service/email_attachment_extractor.rb
@@ -2,7 +2,8 @@ class EmailAttachmentExtractor
   def self.find(
     id:,
     expected_emails: nil,
-    find_criteria: nil
+    find_criteria: nil,
+    include_whole_email: false
   )
     tries = 1
     max_tries = 20
@@ -24,8 +25,12 @@ class EmailAttachmentExtractor
     if tries == max_tries || !email_finder.email_received?
       raise "Email '#{email_finder.id}' not found"
     else
-      email_finder.attachments.tap do
-        email_finder.remove_emails
+      if include_whole_email == true
+        email_finder.emails
+      else
+        email_finder.attachments.tap do
+          email_finder.remove_emails
+        end
       end
     end
   end

--- a/integration/spec/support/email_output_service/inbox.rb
+++ b/integration/spec/support/email_output_service/inbox.rb
@@ -14,13 +14,21 @@ class Inbox
       subject = Array(
         email.payload.headers
       ).find { |header| header.name == 'Subject' }&.value
+      reply_to = Array(
+        email.payload.headers
+      ).find { |header| header.name == 'Reply-To' }&.value
+      from = Array(
+        email.payload.headers
+      ).find { |header| header.name == 'From' }&.value
 
       AcceptanceTestEmail.new(
         email_id: email.id,
         subject: subject,
         snippet: email.snippet,
         attachments: all_attachments_for(email),
-        raw: email
+        raw: email,
+        reply_to: reply_to,
+        from: from
       )
     end
   end


### PR DESCRIPTION
With the Reply-To feature, a user can configure their reply to email address, which should appear in the Reply-to label in an email client.

We have also changed the format of the 'From' label to use the Service name instead of the email address.

Note: The [Runner](https://github.com/ministryofjustice/fb-runner/pull/1113) and [Submitter](https://github.com/ministryofjustice/fb-submitter/pull/819) need to be merged before we can merge this in.