### PR TITLE
Update tests for latest feedback

### DIFF
--- a/integration/spec/features/v2/save_and_return_spec.rb
+++ b/integration/spec/features/v2/save_and_return_spec.rb
@@ -44,6 +44,7 @@ describe 'Save and return' do
     # cancel then answer another question then save progress
     form.cancel_saving.click
     form.question_2.set(q2_answer)
+    continue
     form.save_and_return.click
     sleep 1
     form.email.set('fb-acceptance-tests@digital.justice.gov.uk')

--- a/integration/spec/features/v2/save_and_return_spec.rb
+++ b/integration/spec/features/v2/save_and_return_spec.rb
@@ -65,7 +65,7 @@ describe 'Save and return' do
 
     form.reject.click
     expect(page.text).to include('Your form has been saved')
-    expect(page.text).to include('We have sent a one-off link to fb-acceptance-tests@digital.justice.gov.uk')
+    expect(page.text).to include('We have sent a one-off link')
     sleep 10
     resume_progress_email = get_resume_email('save-and-return-v2-acceptance-test')
     resume_link = extract_link_from_email(resume_progress_email)

--- a/integration/spec/features/v2/save_and_return_spec.rb
+++ b/integration/spec/features/v2/save_and_return_spec.rb
@@ -65,7 +65,6 @@ describe 'Save and return' do
 
     form.reject.click
     expect(page.text).to include('Your form has been saved')
-    expect(page.text).to include('We have sent a one-off link to fb-acceptance-tests@digital.justice.gov.uk')
     sleep 10
     resume_progress_email = get_resume_email('save-and-return-v2-acceptance-test')
     resume_link = extract_link_from_email(resume_progress_email)

--- a/integration/spec/features/v2/save_and_return_spec.rb
+++ b/integration/spec/features/v2/save_and_return_spec.rb
@@ -65,7 +65,7 @@ describe 'Save and return' do
 
     form.reject.click
     expect(page.text).to include('Your form has been saved')
-    expect(page.text).to include('We have sent a one-off link')
+    expect(page.text).to include('We have sent a one-off link to fb-acceptance-tests@digital.justice.gov.uk')
     sleep 10
     resume_progress_email = get_resume_email('save-and-return-v2-acceptance-test')
     resume_link = extract_link_from_email(resume_progress_email)

--- a/integration/spec/features/v2/save_and_return_spec.rb
+++ b/integration/spec/features/v2/save_and_return_spec.rb
@@ -12,6 +12,7 @@ describe 'Save and return' do
   let(:generated_name) { "FN-#{SecureRandom.uuid}" }
   let(:error_message) { 'There is a problem' }
   let(:q1_answer) { 'Hello' }
+  let(:q2_answer) { 'Goodybe' }
 
   before { form.load }
   # comment above line and uncomment below and export user and password ENV vars for local testing

--- a/integration/spec/support/pages/save_and_return_v2_app.rb
+++ b/integration/spec/support/pages/save_and_return_v2_app.rb
@@ -7,7 +7,12 @@ class SaveAndReturnV2App < FeaturesEmailApp
   element :start_button, :button, 'Start now'
   element :continue_form, :link, 'Continue'
   element :question_1, :field, 'Question'
+  element :question_2, :field, 'The Second Question'
+  element :question_3, :field, 'The Third Question'
   element :save_and_return, :button, 'Save for later'
+  element :reject, :button, 'Reject analytics cookies'
+
+  element :cancel_saving, :link, 'Cancel saving and resume form'
   element :email, :field, 'Email address'
   element :secret_answer, :field, 'The answer to your security question'
   element :secret_question_1, :radio_button, 'What is your mother\'s maiden name?', visible: false


### PR DESCRIPTION
- Test additional validation on confirm email
- test for bug where save and return goes to first question page save for later is clicked on
- test for error when making a cookie preference selection on saved progress confirmation page
- update select email code to filter emails to today's date and select newest email by time received