### PR TITLE
Base adapter url missing env

### DIFF
--- a/integration/tests.env.ci
+++ b/integration/tests.env.ci
@@ -20,6 +20,7 @@ NEW_RUNNER_APP="https://%{user}:%{password}@new-runner-acceptance-tests.dev.test
 NEW_RUNNER_BRANCHING_APP="https://%{user}:%{password}@acceptance-tests-branching-fixture-10.dev.test.form.service.justice.gov.uk/"
 SAVE_AND_RETURN_V2_APP="https://%{user}:%{password}@save-and-return-v2-acceptance-test.dev.test.form.service.justice.gov.uk/"
 JSON_SUBMISSION_API_V2_APP="https://%{user}:%{password}@json-acceptance-test.dev.test.form.service.justice.gov.uk/"
+FORM_BUILDER_BASE_ADAPTER_ENDPOINT: https://formbuilder-base-adapter-test.apps.live.cloud-platform.service.justice.gov.uk
 
 ## See what to do with this env vars. The tests require this to boot
 ## but aren't needed when run in CI mode.

--- a/integration/tests.env.ci
+++ b/integration/tests.env.ci
@@ -20,7 +20,7 @@ NEW_RUNNER_APP="https://%{user}:%{password}@new-runner-acceptance-tests.dev.test
 NEW_RUNNER_BRANCHING_APP="https://%{user}:%{password}@acceptance-tests-branching-fixture-10.dev.test.form.service.justice.gov.uk/"
 SAVE_AND_RETURN_V2_APP="https://%{user}:%{password}@save-and-return-v2-acceptance-test.dev.test.form.service.justice.gov.uk/"
 JSON_SUBMISSION_API_V2_APP="https://%{user}:%{password}@json-acceptance-test.dev.test.form.service.justice.gov.uk/"
-FORM_BUILDER_BASE_ADAPTER_ENDPOINT: https://formbuilder-base-adapter-test.apps.live.cloud-platform.service.justice.gov.uk
+FORM_BUILDER_BASE_ADAPTER_ENDPOINT="https://formbuilder-base-adapter-test.apps.live.cloud-platform.service.justice.gov.uk"
 
 ## See what to do with this env vars. The tests require this to boot
 ## but aren't needed when run in CI mode.


### PR DESCRIPTION
This is to fix a failed runner deployment that is missing environment variable for the base adapter url used for API submission acceptance tests.