### PR TITLE
Adding test for users answers to be included in confirmation email

### DIFF
--- a/integration/spec/features/v2/new_runner_spec.rb
+++ b/integration/spec/features/v2/new_runner_spec.rb
@@ -216,9 +216,11 @@ describe 'New Runner' do
     expect(page.text).to include(reference_number)
 
     confirmation_email = get_confirmation_email(reference_number)
+    message_body = email_body(confirmation_email[0])
 
     expect(confirmation_email[0].reply_to).to include('fb-acceptance-tests+reply-to@digital.justice.gov.uk')
     expect(confirmation_email[0].from).to include('new-runner-acceptance-tests')
+    expect(message_body).to include('Wakanda', 'Where do you like to holiday?')
 
     pdf_attachments = find_pdf_attachments(id: reference_number, expected_emails: 2)
     csv_attachments = find_csv_attachments(id: reference_number)
@@ -374,5 +376,9 @@ describe 'New Runner' do
       '',
       'WK'
     ])
+  end
+
+  def email_body(email)
+    email.raw.payload.parts[0].parts[0].body.data
   end
 end

--- a/integration/spec/features/v2/new_runner_spec.rb
+++ b/integration/spec/features/v2/new_runner_spec.rb
@@ -224,7 +224,7 @@ describe 'New Runner' do
     expect(confirmation_email[0].reply_to).to include('fb-acceptance-tests+reply-to@digital.justice.gov.uk')
     expect(confirmation_email[0].from).to include('new-runner-acceptance-tests')
 
-    some_answers = 'First name Stormtrooper'
+    some_answers = 'First nameStormtrooper'
     expect(confirmation_message_body).to include(some_answers)
     expect(submission_message_body).to include(some_answers)
 

--- a/integration/spec/features/v2/new_runner_spec.rb
+++ b/integration/spec/features/v2/new_runner_spec.rb
@@ -216,11 +216,17 @@ describe 'New Runner' do
     expect(page.text).to include(reference_number)
 
     confirmation_email = get_confirmation_email(reference_number)
-    message_body = email_body(confirmation_email[0])
+    submission_email = get_submission_email(reference_number)
+
+    confirmation_message_body = email_body(confirmation_email[0])
+    submission_message_body = email_body(submission_email[0])
 
     expect(confirmation_email[0].reply_to).to include('fb-acceptance-tests+reply-to@digital.justice.gov.uk')
     expect(confirmation_email[0].from).to include('new-runner-acceptance-tests')
-    expect(message_body).to include('Wakanda', 'Where do you like to holiday?')
+
+    some_answers = 'First name Stormtrooper'
+    expect(confirmation_message_body).to include(some_answers)
+    expect(submission_message_body).to include(some_answers)
 
     pdf_attachments = find_pdf_attachments(id: reference_number, expected_emails: 2)
     csv_attachments = find_csv_attachments(id: reference_number)
@@ -380,5 +386,11 @@ describe 'New Runner' do
 
   def email_body(email)
     email.raw.payload.parts[0].parts[0].body.data
+  end
+
+  def get_submission_email(reference_number)
+    find_email_by_subject(id: reference_number).select do |email|
+      email.subject.include?('Submission from')
+    end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/EAS6JZuE/3718-add-submission-data-in-the-email-body-of-the-submission-email)

Adding tests to check if we have the user answers in the body of the email.

Test passing with runner and submitter: [circleci](https://app.circleci.com/pipelines/github/ministryofjustice/fb-acceptance-tests/5499/workflows/b9a52b2f-5f5b-4968-aa0a-31ebafb3cc3b)
