### PR TITLE
Do not use parallel_rspec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ endif
 ## Experimental ##
 spec-ci:
 	docker-compose -f docker-compose.ci.yml run --rm integration_ci \
-	bundle exec parallel_rspec $(or $(SPEC_DIR),spec) -n 4 -o '--fail-fast'
+	bundle exec rspec $(or $(SPEC_DIR),spec) --fail-fast
 
 ## Clears out emails older than 24 hours from the gmail inbox that receives test submissions
 clear-emails:

--- a/integration/.rspec
+++ b/integration/.rspec
@@ -1,3 +1,2 @@
 --require spec_helper
 -f doc
---format ParallelTests::RSpec::SummaryLogger


### PR DESCRIPTION
Using parallelism might be having an impact increasing flaky tests.
We can disable this for a while and observe.

So far out of 3 workflow runs, all 3 succeeded in the first attempt with no failures/flakes.

In other repos that clone this repo and run the tests might be different and also timing will be increased. In this repo we are running 4 logical groups of tests in 4 separate jobs making it quicker.