### PR TITLE
chore: Fix typo

### DIFF
--- a/integration/spec/features/v2/save_and_return_spec.rb
+++ b/integration/spec/features/v2/save_and_return_spec.rb
@@ -83,7 +83,7 @@ describe 'Save and return' do
     sleep 1
     continue
     sleep 1
-    expect(page.text).to include('You have sucessfuly retrieved your saved information.')
+    expect(page.text).to include('You have successfully retrieved your saved information.')
     expect(page.text).to include(q1_answer)
     expect(page.text).to include(q2_answer)
     form.continue_form.click


### PR DESCRIPTION
This typo was fixed in the metadata presenter so this test should now also use the correct word otherwise test will fail.