### PR TITLE
Update dependencies and rename main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - clear_old_emails:
           context: *context

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ministryofjustice/form-builder-pr-reviewers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,22 @@
 version: 2
 updates:
 - package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+  # Disable version updates, but leave security updates
+  open-pull-requests-limit: 0
+
+- package-ecosystem: bundler
   directory: "/integration"
   schedule:
     interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  reviewers:
-  - mattempty
-  - chrispymm
-  - H3ll3m4
-  - StevenLeighton21
+  # Disable version updates, but leave security updates
+  open-pull-requests-limit: 0
+
 - package-ecosystem: docker
   directory: "/integration"
   schedule:
     interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  reviewers:
-  - mattempty
-  - chrispymm
-  - H3ll3m4
-  - StevenLeighton21
+  # Disable version updates, but leave security updates
+  open-pull-requests-limit: 0

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'http://rubygems.org'
 
-gem 'activesupport'
+gem 'activesupport', '~> 7.1.0'
 gem 'procodile'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (7.1.1)
+    activesupport (7.1.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -32,7 +32,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
+  activesupport (~> 7.1.0)
   procodile
 
 BUNDLED WITH

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022-2023 Crown Copyright (Ministry of Justice)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/integration/Gemfile
+++ b/integration/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'activesupport'
+gem 'activesupport', '~> 7.1.0'
 gem 'byebug'
 gem 'capybara'
 gem 'dotenv'
@@ -8,9 +8,6 @@ gem 'google-apis-gmail_v1'
 gem 'httparty'
 gem 'jwe'
 gem 'mail'
-gem 'net-imap', require: false
-gem 'net-pop', require: false
-gem 'net-smtp', require: false
 gem 'parallel_tests'
 gem 'pdf-reader'
 gem 'rspec'

--- a/integration/Gemfile.lock
+++ b/integration/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     Ascii85 (1.1.0)
-    activesupport (7.1.1)
+    activesupport (7.1.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -35,7 +35,7 @@ GEM
     dotenv (2.8.1)
     drb (2.2.0)
       ruby2_keywords
-    faraday (2.7.11)
+    faraday (2.7.12)
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -49,7 +49,7 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
-    google-apis-gmail_v1 (0.35.0)
+    google-apis-gmail_v1 (0.36.0)
       google-apis-core (>= 0.11.0, < 2.a)
     googleauth (1.8.1)
       faraday (>= 0.17.3, < 3.a)
@@ -78,7 +78,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     mutex_m (0.2.0)
-    net-imap (0.4.4)
+    net-imap (0.4.7)
       date
       net-protocol
     net-pop (0.1.2)
@@ -87,7 +87,7 @@ GEM
       timeout
     net-smtp (0.4.0)
       net-protocol
-    nokogiri (1.15.4)
+    nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
@@ -100,7 +100,7 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    public_suffix (5.0.3)
+    public_suffix (5.0.4)
     racc (1.7.3)
     rack (3.0.8)
     rack-test (2.1.0)
@@ -157,7 +157,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
+  activesupport (~> 7.1.0)
   byebug
   capybara
   dotenv
@@ -165,9 +165,6 @@ DEPENDENCIES
   httparty
   jwe
   mail
-  net-imap
-  net-pop
-  net-smtp
   parallel_tests
   pdf-reader
   rspec


### PR DESCRIPTION
Some more minor bumps to gems to close dependabots. Removed unneeded gems.

Reduce noise in dependabot by configuring it to only raise PRs for security versions, and not for version updates.

Renamed `master` branch to `main` and update CircleCI config.