### PR TITLE
Cleanup unneeded code

### DIFF
--- a/integration/smoke_tests/form_spec.rb
+++ b/integration/smoke_tests/form_spec.rb
@@ -22,20 +22,6 @@ class SmokeTestForm < ServiceApp
   element :postcode, :field, 'Text Field with Postcode Regex'
   element :red, :checkbox, 'Red', visible: false
   element :add_upload, :radio_button, 'Yes, add this upload', visible: false
-
-  # Service app will log the url which will contain user
-  # and password.
-  # Overwriting the signature method will
-  # make the tests to not print anything.
-  def load(expansion_or_html = {}, &block)
-    puts "Visiting form: #{ENV['SMOKE_TEST_FORM'] % { user: '*****', password: '*****' }}"
-
-    load_with_retry(app: self.class.name) do
-      SitePrism::Page.instance_method(:load).bind(self).call
-    end
-
-    self.wait_until_displayed
-  end
 end
 
 describe 'Smoke test' do

--- a/integration/smoke_tests_v2/form_spec.rb
+++ b/integration/smoke_tests_v2/form_spec.rb
@@ -21,20 +21,6 @@ class SmokeTestV2RunnerForm < ServiceApp
   element :another_number_field, :field, 'Number'
   element :postcode, :field, 'Text Field with Postcode'
   element :red, :checkbox, 'Red', visible: false
-
-  # Service app will log the url which will contain user
-  # and password.
-  # Overwriting the signature method will
-  # make the tests to not print anything.
-  def load(expansion_or_html = {}, &block)
-    puts "Visiting form: #{ENV['SMOKE_TEST_FORM_V2'] % { user: '*****', password: '*****' }}"
-
-    load_with_retry(app: self.class.name) do
-      SitePrism::Page.instance_method(:load).bind(self).call
-    end
-
-    self.wait_until_displayed
-  end
 end
 
 describe 'Smoke test' do

--- a/integration/spec/features/v1/maintenance_mode_spec.rb
+++ b/integration/spec/features/v1/maintenance_mode_spec.rb
@@ -34,7 +34,7 @@ describe 'Maintenance mode' do
 
     context 'when visiting the maintenance page' do
       it 'does not redirect requests to the maintenance page' do
-        form.load('restricted/maintenance')
+        form.load(url: 'restricted/maintenance')
 
         expect(form.text).to_not include(maintenance_content)
       end

--- a/integration/spec/support/pages/new_runner_app.rb
+++ b/integration/spec/support/pages/new_runner_app.rb
@@ -17,14 +17,4 @@ class NewRunnerApp < FeaturesEmailApp
   element :change_cat, :link, text: 'Your answer for Your cat', visible: false
   element :change_upload, :link, text: 'Your answer for Upload a file', visible: false
   element :change_autocomplete, :link, text: 'Where do you like to holiday?', visible: false
-
-  def load(expansion_or_html = {}, &block)
-    puts "Visiting form: #{ENV['NEW_RUNNER_APP'] % { user: '*****', password: '*****' }}"
-
-    load_with_retry(app: self.class.name) do
-      SitePrism::Page.instance_method(:load).bind(self).call
-    end
-
-    self.wait_until_displayed
-  end
 end

--- a/integration/spec/support/pages/new_runner_branching_app.rb
+++ b/integration/spec/support/pages/new_runner_branching_app.rb
@@ -23,14 +23,4 @@ class NewRunnerBranchingApp < ServiceApp
 
   element :change_page_b_answer, :link, text: 'Your answer for Page B', visible: false
   element :change_page_j_answer, :link, text: 'Your answer for Page J', visible: false
-
-  def load(expansion_or_html = {}, &block)
-    puts "Visiting form: #{ENV['NEW_RUNNER_BRANCHING_APP'] % { user: '*****', password: '*****' }}"
-
-    load_with_retry(app: self.class.name) do
-      SitePrism::Page.instance_method(:load).bind(self).call
-    end
-
-    self.wait_until_displayed
-  end
 end

--- a/integration/spec/support/pages/save_and_return_v2_app.rb
+++ b/integration/spec/support/pages/save_and_return_v2_app.rb
@@ -20,14 +20,4 @@ class SaveAndReturnV2App < FeaturesEmailApp
   element :secret_question_3, :radio_button, 'What is the name of the hospital where you were born?', visible: false
   element :email_confirmation, :field, 'Check your email address is correct'
   element :resume_secret_answer, :field, 'What is your mother\'s maiden name?'
-
-  def load(expansion_or_html = {}, &block)
-    puts "Visiting form: #{ENV['SAVE_AND_RETURN_V2_APP'] % { user: '*****', password: '*****' }}"
-
-    load_with_retry(app: self.class.name) do
-      SitePrism::Page.instance_method(:load).bind(self).call
-    end
-
-    self.wait_until_displayed
-  end
 end


### PR DESCRIPTION
These `#load` methods are not needed, as the one in the superclass `ServiceApp` does the same `load_with_retry` and also the redacting of the URL is not needed as siteprism has builtin redacting.

Once this is merged I will rebase PR #392.