### PR TITLE
Update number of PDF received

### DIFF
--- a/integration/spec/features/v2/new_runner_spec.rb
+++ b/integration/spec/features/v2/new_runner_spec.rb
@@ -240,7 +240,7 @@ describe 'New Runner' do
     expect(submission_message_body).to include(some_answers)
     expect(submission_csv_message_body).to be_blank
 
-    pdf_attachments = find_pdf_attachments(id: reference_number, expected_emails: 2)
+    pdf_attachments = find_pdf_attachments(id: reference_number, expected_emails: 1)
     csv_attachments = find_csv_attachments(id: reference_number)
 
     assert_pdf_contents(pdf_attachments, reference_number)


### PR DESCRIPTION
As part of the protective markings work, we are removing the PDF from the confirmation email, thus we will only get one PDF, in the submission email.


To be merged right before the protective markings work in runner/submitter/pdf-generator.