### PR TITLE
Update error message for file uploads

### DIFF
--- a/integration/spec/features/v2/new_runner_spec.rb
+++ b/integration/spec/features/v2/new_runner_spec.rb
@@ -111,6 +111,7 @@ describe 'New Runner' do
     check_optional_text(page.text)
     continue
     check_error_message(page.text, [form.find('h1').text])
+    check_validation_error_message('Choose a file to upload')
     attach_file('Upload a file', 'spec/fixtures/files/hello_world.txt')
     continue
 
@@ -123,6 +124,7 @@ describe 'New Runner' do
     check_optional_text(page.text)
     continue
     check_error_message(page.text, [form.find('h1').text]) # required
+    check_validation_error_message('Choose a file to upload')
     attach_file('answers-multifile-multiupload-1-field-error', 'spec/fixtures/files/hello_world_multi_1.txt')
     continue
     expect(page.text).to include('hello_world_multi_1.txt')

--- a/integration/spec/features/v2/new_runner_spec.rb
+++ b/integration/spec/features/v2/new_runner_spec.rb
@@ -110,7 +110,7 @@ describe 'New Runner' do
     # attach file
     check_optional_text(page.text)
     continue
-    check_error_message(page.text, [form.find('h1').text])
+    expect(page.text).to include(error_message) # required
     check_validation_error_message('Choose a file to upload')
     attach_file('Upload a file', 'spec/fixtures/files/hello_world.txt')
     continue
@@ -123,7 +123,7 @@ describe 'New Runner' do
     # attach file to multi file
     check_optional_text(page.text)
     continue
-    check_error_message(page.text, [form.find('h1').text]) # required
+    expect(page.text).to include(error_message) # required
     check_validation_error_message('Choose a file to upload')
     attach_file('answers-multifile-multiupload-1-field-error', 'spec/fixtures/files/hello_world_multi_1.txt')
     continue


### PR DESCRIPTION
https://trello.com/c/r3wfBU4f

The latest metadata presenter changes the "required" error message for file uploads, from the generic shown for all other components.

Add a explicit error message check to catch any potential regressions.